### PR TITLE
Zeus spawner reinforcements

### DIFF
--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -18,12 +18,15 @@
 
 params ["_unitarray", "_position", "_vehicletype", ["_faction",""], ["_side", f_defaultSide], ["_suppressive",false], ["_guerrilla",false], ["_enableAdvancedAI",true], ["_runAfter",[]], ["_reinforcementarray", []]];
 
+
+_reinfExists = ((count _reinforcementarray) > 0);
+
 _vehicle = [_position, _vehicletype] call f_fnc_spawnVehicle;
 _group = [_unitarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
-_reinfgroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
+
+
 
 _units = units _group;
-_reinf = units _reinfgroup;
 _assigned = [];
 
 _comno = true;
@@ -91,20 +94,45 @@ _gunno = true;
 
 _units orderGetIn true;
 
+
+
+if (_reinfExists) then
 {
 
-    _check = (_x in _assigned);
+        _reinfgroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
+        _reinf = units _reinfgroup;
 
-    if (!_check) then
-    {
-        _x assignAsCargo _vehicle;
-        _x moveInAny _vehicle;
-        _assigned pushBackUnique _x;
+        {
 
-    };
+              _check = (_x in _assigned);
+
+                if (!_check) then
+                {
+                      _x assignAsCargo _vehicle;
+                      _x moveInAny _vehicle;
+                      _assigned pushBackUnique _x;
+
+                };
 
 
-}forEach _reinf;
+        }forEach _reinf;
+
+        _unloadPos = _vehicle modelToWorld [0,100,0];
+        _movePos = _vehicle modelToWorld [25,50,0];
+        _reinfPos = _vehicle modelToWorld [0,200,0];
+        _wp = _group addWaypoint [_unloadPos,0,0];
+        _wp setWaypointType "TR UNLOAD";
+        [_group, 1]setWaypointPosition [_movePos,0];
+
+        _wp = _reinfgroup addWaypoint [_reinfPos,0,0];
+        deleteWaypoint [_reinfgroup, 1];
+
+        if ((typeName _runAfter) isEqualTo "CODE") then
+        {
+	        [_reinfgroup]call _runAfter;
+        };
+
+};
 
 
 if ((typeName _runAfter) isEqualTo "CODE") then

--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -16,12 +16,14 @@
  *
  */
 
-params ["_unitarray", "_position", "_vehicletype", ["_faction",""], ["_side", f_defaultSide], ["_suppressive",false], ["_guerrilla",false], ["_enableAdvancedAI",true], ["_runAfter",[]]];
+params ["_unitarray", "_position", "_vehicletype", ["_faction",""], ["_side", f_defaultSide], ["_suppressive",false], ["_guerrilla",false], ["_enableAdvancedAI",true], ["_runAfter",[]], ["_reinforcementarray", []]];
 
 _vehicle = [_position, _vehicletype] call f_fnc_spawnVehicle;
 _group = [_unitarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
+_reinfgroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
 
 _units = units _group;
+_reinf = units _reinfgroup;
 _assigned = [];
 
 _comno = true;
@@ -88,6 +90,21 @@ _gunno = true;
 } forEach _units;
 
 _units orderGetIn true;
+
+{
+
+    _check = (_x in _assigned);
+
+    if (!_check) then
+    {
+        _x assignAsCargo _vehicle;
+        _x moveInAny _vehicle;
+        _assigned pushBackUnique _x;
+
+    };
+
+
+}forEach _reinf;
 
 
 if ((typeName _runAfter) isEqualTo "CODE") then

--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -1,8 +1,8 @@
 #include "macros.hpp"
 
 /*
- * Author: Poulern
- * Spawns a vehicle with a crew inside of it
+ * Author: Poulern, edited by Joecuronium and Bubbus.
+ * Spawns a vehicle with a crew inside of it and an optional transported reinforcement squad.
  *
  * Arguments:
  * 0: F3 group array
@@ -12,14 +12,14 @@
  * 4: Side of units spawned, west east independent
  *
  * Return Value:
- * Array of [group,vehicle]
+ * Array of [group, vehicle, reinforcement group]
  *
  */
 
 params ["_unitarray", "_position", "_vehicletype", ["_faction",""], ["_side", f_defaultSide], ["_suppressive",false], ["_guerrilla",false], ["_enableAdvancedAI",true], ["_runAfter",[]], ["_reinforcementarray", []]];
 
 
-_reinfExists = ((count _reinforcementarray) > 0);
+_reinforcementsExist = ((count _reinforcementarray) > 0);
 
 _vehicle = [_position, _vehicletype] call f_fnc_spawnVehicle;
 _group = [_unitarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
@@ -95,53 +95,44 @@ _gunno = true;
 _units orderGetIn true;
 
 
-
-if (_reinfExists) then
+if (_reinforcementsExist) then
 {
+    _reinforcementsGroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
+    _reinforcementUnits = units _reinforcementsGroup;
 
-        _reinfgroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
-        _reinf = units _reinfgroup;
+    {
+        _check = (_x in _assigned);
 
+        if (!_check) then
         {
-
-              _check = (_x in _assigned);
-
-                if (!_check) then
-                {
-                      _x assignAsCargo _vehicle;
-                      _x moveInAny _vehicle;
-                      _assigned pushBackUnique _x;
-
-                };
-
-
-        }forEach _reinf;
-
-        _unloadPos = _vehicle modelToWorld [0,100,0];
-        
-        _reinfPos = _vehicle modelToWorld [0,200,0];
-        _wp = _group addWaypoint [_unloadPos,0,0];
-        _wp setWaypointType "TR UNLOAD";
-
-        if (!_gunno) then                       //Check if vehicle has Gunner, if yes, it holds at unloadPos, if no it returns to spawn (doesn't always work because ARMA)
-        {
-            deleteWaypoint[_group,1];
+            _x assignAsCargo _vehicle;
+            _x moveInAny _vehicle;
+            _assigned pushBackUnique _x;
         };
 
-        _wp = _reinfgroup addWaypoint [_reinfPos,0,0];
-        deleteWaypoint [_reinfgroup, 1];
+    } forEach _reinforcementUnits;
 
-        if ((typeName _runAfter) isEqualTo "CODE") then
-        {
-	        [_reinfgroup]call _runAfter;
-        };
+    _unloadPos = _vehicle modelToWorld [0,100,0];
+    _reinfPos = _vehicle modelToWorld [0,200,0];
+
+    _crewWaypoint = _group addWaypoint [_unloadPos, 0, 0];
+    _crewWaypoint setWaypointType "TR UNLOAD";
+
+    //Check if vehicle has Gunner, if yes, it holds at unloadPos, if no it returns to spawn (doesn't always work because ARMA)
+    if (!_gunno) then
+    {
+        deleteWaypoint [_group,1];
+    };
+
+    _squadWaypoint = _reinforcementsGroup addWaypoint [_reinfPos, 0, 0];
+    deleteWaypoint [_reinforcementsGroup, 1];
 
 };
 
 
 if ((typeName _runAfter) isEqualTo "CODE") then
 {
-	[_group, _vehicle] call _runAfter;
+	[_group, _vehicle, _reinforcementsGroup] call _runAfter;
 };
 
-[_group, _vehicle]
+[_group, _vehicle, _reinforcementsGroup]

--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -118,11 +118,15 @@ if (_reinfExists) then
         }forEach _reinf;
 
         _unloadPos = _vehicle modelToWorld [0,100,0];
-        _movePos = _vehicle modelToWorld [25,50,0];
+        
         _reinfPos = _vehicle modelToWorld [0,200,0];
         _wp = _group addWaypoint [_unloadPos,0,0];
         _wp setWaypointType "TR UNLOAD";
-        [_group, 1]setWaypointPosition [_movePos,0];
+
+        if (!_gunno) then                       //Check if vehicle has Gunner, if yes, it holds at unloadPos, if no it returns to spawn (doesn't always work because ARMA)
+        {
+            deleteWaypoint[_group,1];
+        };
 
         _wp = _reinfgroup addWaypoint [_reinfPos,0,0];
         deleteWaypoint [_reinfgroup, 1];

--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -95,10 +95,14 @@ _gunno = true;
 _units orderGetIn true;
 
 
+private _returnList = [_group, _vehicle];
+
 if (_reinforcementsExist) then
 {
     _reinforcementsGroup = [_reinforcementarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
     _reinforcementUnits = units _reinforcementsGroup;
+
+    _returnList = _returnList + [_reinforcementsGroup];
 
     {
         _check = (_x in _assigned);
@@ -132,7 +136,7 @@ if (_reinforcementsExist) then
 
 if ((typeName _runAfter) isEqualTo "CODE") then
 {
-	[_group, _vehicle, _reinforcementsGroup] call _runAfter;
+	_returnList call _runAfter;
 };
 
-[_group, _vehicle, _reinforcementsGroup]
+_returnList

--- a/components/zeus_ui/config/macros.hpp
+++ b/components/zeus_ui/config/macros.hpp
@@ -151,6 +151,7 @@
 
 	#define MACRO_VARNAME_UNIT_ROLES                                        "roles"
 	#define MACRO_VARNAME_UNIT_VEHICLE                                      "vehicle"
+	#define MACRO_VARNAME_REINFORCEMENT_ROLES								"reinforcements"
 
 	// Third-party mods/scripts
 	#define MACRO_VCOM_VARNAME_NOAI                                         "Vcm_Disable"		// Taken from "vcomai\Vcom\Functions\VcomAI_DefaultSettings.sqf"

--- a/components/zeus_ui/events/ui_spawn.sqf
+++ b/components/zeus_ui/events/ui_spawn.sqf
@@ -25,6 +25,7 @@ case "ui_spawn": {
 
 		// Fetch the roles list and the vehicle (if we have one)
 		private _roles = _unitNamespace getVariable [MACRO_VARNAME_UNIT_ROLES, []];
+		private _reinfRoles = _unitNamespace getVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, []];
 		private _vehicleClass = _unitNamespace getVariable [MACRO_VARNAME_UNIT_VEHICLE, ""];
 
 		// Only continue if we have valid data to spawn anything with
@@ -88,7 +89,7 @@ case "ui_spawn": {
 
 				// Tell the server to spawn the group
 				f_fnc_server_spawnGroup = compile preprocessFileLineNumbers "components\zeus_ui\fn_server_spawnGroup.sqf";
-				[_roles, _pos, _gear, _side, _vehicleClass, _enableAdvancedAI, _guerrillaAI, _suppressiveAI] remoteExec ["f_fnc_server_spawnGroup", 2, false];
+				[_roles, _pos, _gear, _side, _vehicleClass, _enableAdvancedAI, _guerrillaAI, _suppressiveAI, _reinfRoles] remoteExec ["f_fnc_server_spawnGroup", 2, false];
 			};
 		};
 	};

--- a/components/zeus_ui/events/ui_spawn.sqf
+++ b/components/zeus_ui/events/ui_spawn.sqf
@@ -25,7 +25,7 @@ case "ui_spawn": {
 
 		// Fetch the roles list and the vehicle (if we have one)
 		private _roles = _unitNamespace getVariable [MACRO_VARNAME_UNIT_ROLES, []];
-		private _reinfRoles = _unitNamespace getVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, []];
+		private _reinforcementRoles = _unitNamespace getVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, []];
 		private _vehicleClass = _unitNamespace getVariable [MACRO_VARNAME_UNIT_VEHICLE, ""];
 
 		// Only continue if we have valid data to spawn anything with
@@ -89,7 +89,7 @@ case "ui_spawn": {
 
 				// Tell the server to spawn the group
 				f_fnc_server_spawnGroup = compile preprocessFileLineNumbers "components\zeus_ui\fn_server_spawnGroup.sqf";
-				[_roles, _pos, _gear, _side, _vehicleClass, _enableAdvancedAI, _guerrillaAI, _suppressiveAI, _reinfRoles] remoteExec ["f_fnc_server_spawnGroup", 2, false];
+				[_roles, _pos, _gear, _side, _vehicleClass, _enableAdvancedAI, _guerrillaAI, _suppressiveAI, _reinforcementRoles] remoteExec ["f_fnc_server_spawnGroup", 2, false];
 			};
 		};
 	};

--- a/components/zeus_ui/fn_addToCurator.sqf
+++ b/components/zeus_ui/fn_addToCurator.sqf
@@ -4,8 +4,24 @@ RUN_ON_SERVER(f_fnc_addToCurator,_this);
 
 params [["_group", grpNull], ["_vehicle", objNull]];
 
-// Add the units as editable objects
-private _allObjects = (units _group) + [_vehicle];
+
+// Generate a flat list of all objects to add to curators.
+private _allObjects = [];
+
+{
+	_newObjects = switch (typeName _x) do
+	{
+		case ("GROUP"): {units _x};
+		case ("ARRAY"): {_x};
+	    default {[_x]};
+	};
+
+	_allObjects = _allObjects + _newObjects;
+
+} forEach _this;
+
+
+// Add the units as editable objects.
 {
 	_x addCuratorEditableObjects [_allObjects, true];
 } forEach allCurators;

--- a/components/zeus_ui/fn_compileLists.sqf
+++ b/components/zeus_ui/fn_compileLists.sqf
@@ -54,9 +54,11 @@ private _allCategoriesVars = [];
 		private _unitName = [_x, "unitName", ""] call BIS_fnc_returnConfigEntry;
 		private _unitVehicle = [_x, "vehicle", ""] call BIS_fnc_returnConfigEntry;
 		private _unitRoles = [_x, "units", []] call BIS_fnc_returnConfigEntry;
+		private _reinfRoles = [_x, "reinforcements", []] call BIS_fnc_returnConfigEntry;
 
 		// Fill the data of the namespace
 		_unitNamespace setVariable [MACRO_VARNAME_UNIT_ROLES, _unitRoles];
+		_unitNamespace setVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, _reinfRoles];
 		_unitNamespace setVariable [MACRO_VARNAME_UNIT_VEHICLE, _unitVehicle];
 
 		// Save the unit namespace

--- a/components/zeus_ui/fn_compileLists.sqf
+++ b/components/zeus_ui/fn_compileLists.sqf
@@ -54,11 +54,11 @@ private _allCategoriesVars = [];
 		private _unitName = [_x, "unitName", ""] call BIS_fnc_returnConfigEntry;
 		private _unitVehicle = [_x, "vehicle", ""] call BIS_fnc_returnConfigEntry;
 		private _unitRoles = [_x, "units", []] call BIS_fnc_returnConfigEntry;
-		private _reinfRoles = [_x, "reinforcements", []] call BIS_fnc_returnConfigEntry;
+		private _reinforcementRoles = [_x, "reinforcements", []] call BIS_fnc_returnConfigEntry;
 
 		// Fill the data of the namespace
 		_unitNamespace setVariable [MACRO_VARNAME_UNIT_ROLES, _unitRoles];
-		_unitNamespace setVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, _reinfRoles];
+		_unitNamespace setVariable [MACRO_VARNAME_REINFORCEMENT_ROLES, _reinforcementRoles];
 		_unitNamespace setVariable [MACRO_VARNAME_UNIT_VEHICLE, _unitVehicle];
 
 		// Save the unit namespace

--- a/components/zeus_ui/fn_server_spawnGroup.sqf
+++ b/components/zeus_ui/fn_server_spawnGroup.sqf
@@ -21,7 +21,7 @@
 #include "macros.hpp"
 
 // Fetch our params
-params ["_roles", "_pos", "_gear", "_side", ["_vehicleClass", ""], ["_enableAdvancedAI", false], ["_guerrillaAI", false], ["_suppressiveAI", false]];
+params ["_roles", "_pos", "_gear", "_side", ["_vehicleClass", ""], ["_enableAdvancedAI", false], ["_guerrillaAI", false], ["_suppressiveAI", false], ["_reinforcements", []]];
 
 
 private _group = grpNull;
@@ -29,7 +29,7 @@ private _vehicle = objNull;
 
 if (_vehicleClass != "") then
 {
-	_args = [_roles, _pos, _vehicleClass, _gear, _side, _suppressiveAI, _guerrillaAI, _enableAdvancedAI, f_fnc_addToCurator];
+	_args = [_roles, _pos, _vehicleClass, _gear, _side, _suppressiveAI, _guerrillaAI, _enableAdvancedAI, f_fnc_addToCurator, _reinforcements];
 
 	if ((_suppressiveAI isEqualType []) or (_guerrillaAI isEqualType [])) then
 	{

--- a/configuration/zeusSpawner/unitPresets.hpp
+++ b/configuration/zeusSpawner/unitPresets.hpp
@@ -78,7 +78,6 @@ class CA_ZeusUI_Units
 			unitName = "AMV-7 Marshall";
 			vehicle = "B_APC_Wheeled_01_cannon_F";
 			units[] = {"crew", "crew", "crew"};
-			reinforcements[] = {"rif", "rif", "rif"}; 	//This is the reinforcement group to be spawned. They will occupy the cargo spaces of the vehicle.
 		};
 
 		class IFV6C_Panther
@@ -93,6 +92,14 @@ class CA_ZeusUI_Units
 			unitName = "Hunter HMG";
 			vehicle = "B_MRAP_01_HMG_F";
 			units[] = {"crew", "crew", "crew"};
+		};
+
+		class AMV_7_Reinforcements
+		{
+			unitName = "AMV-7 Marshall + Fireteam 4x"
+			vehicle = "B_APC_Wheeled_01_cannon_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat"}; //When defined, this group spawns in the cargo space of the vehicle. The vehicle gets a TR unload waypoint and a Move waypoint, the group a Move waypoint.
 		};
 	};
 

--- a/configuration/zeusSpawner/unitPresets.hpp
+++ b/configuration/zeusSpawner/unitPresets.hpp
@@ -78,6 +78,7 @@ class CA_ZeusUI_Units
 			unitName = "AMV-7 Marshall";
 			vehicle = "B_APC_Wheeled_01_cannon_F";
 			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"rif", "rif", "rif"}; 	//This is the reinforcement group to be spawned. They will occupy the cargo spaces of the vehicle.
 		};
 
 		class IFV6C_Panther

--- a/configuration/zeusSpawner/unitPresets.hpp
+++ b/configuration/zeusSpawner/unitPresets.hpp
@@ -28,13 +28,13 @@ class CA_ZeusUI_Units
 			unitName = "BLUFOR Fireteam 4x";
 			units[] = {"ftl", "ar", "lat", "rif"};
 		};
-		
+
 		class Squad_6x
 		{
 			unitName = "BLUFOR Squad 6x";
 			units[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};	// This spawns a full 6-man fireteam. You can have as many or as few units in a squad as you want.
 		};
-		
+
 		class Section_9x
 		{
 			unitName = "BLUFOR Section 9x";
@@ -52,7 +52,7 @@ class CA_ZeusUI_Units
 			unitName = "BLUFOR AR Team";
 			units[] = {"aar", "ar"};
 		};
-		
+
 		class MK_Team
 		{
 			unitName = "BLUFOR MK Team";
@@ -80,6 +80,14 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class AMV_7_Reinforcements
+		{
+			unitName = "AMV-7 Marshall + Squad 6x"
+			vehicle = "B_APC_Wheeled_01_cannon_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"}; // When defined, this group spawns in the cargo space of the vehicle. The vehicle gets a TR unload waypoint and a Move waypoint, the group a Move waypoint.
+		};
+
 		class IFV6C_Panther
 		{
 			unitName = "IFV-6C Panther";
@@ -87,19 +95,27 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class IFV6C_Panther_Reinforcements
+		{
+			unitName = "IFV-6C Panther + Squad 6x";
+			vehicle = "B_APC_Tracked_01_rcws_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};
+		};
+
 		class Hunter_HMG
 		{
 			unitName = "Hunter HMG";
 			vehicle = "B_MRAP_01_HMG_F";
-			units[] = {"crew", "crew", "crew"};
+			units[] = {"ftl", "rif", "rif"};
 		};
 
-		class AMV_7_Reinforcements
+		class HEMTT_Reinforcements
 		{
-			unitName = "AMV-7 Marshall + Fireteam 4x"
-			vehicle = "B_APC_Wheeled_01_cannon_F";
-			units[] = {"crew", "crew", "crew"};
-			reinforcements[] = {"ftl", "ar", "aar", "lat"}; //When defined, this group spawns in the cargo space of the vehicle. The vehicle gets a TR unload waypoint and a Move waypoint, the group a Move waypoint.
+			unitName = "HEMTT Transport + Section 9x";
+			vehicle = "B_Truck_01_covered_F";
+			units[] = {"rif", "rif"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "med", "mk", "rif", "rif", "rif"};
 		};
 	};
 
@@ -121,13 +137,13 @@ class CA_ZeusUI_Units
 			unitName = "OPFOR Fireteam 4x";
 			units[] = {"ftl", "ar", "lat", "rif"};
 		};
-		
+
 		class Squad_6x
 		{
 			unitName = "OPFOR Squad 6x";
 			units[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};	// This spawns a full 6-man fireteam. You can have as many or as few units in a squad as you want.
 		};
-		
+
 		class Section_9x
 		{
 			unitName = "OPFOR Section 9x";
@@ -145,7 +161,7 @@ class CA_ZeusUI_Units
 			unitName = "OPFOR AR Team";
 			units[] = {"aar", "ar"};
 		};
-		
+
 		class MK_Team
 		{
 			unitName = "OPFOR MK Team";
@@ -173,6 +189,14 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class MSE3_Marid_Reinforcements
+		{
+			unitName = "MSE-3 Marid + Squad 6x";
+			vehicle = "O_APC_Wheeled_02_rcws_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};
+		};
+
 		class BTRK_Kamysh
 		{
 			unitName = "BTR-K Kamysh";
@@ -180,11 +204,27 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class BTRK_Kamysh_Reinforcements
+		{
+			unitName = "BTR-K Kamysh + Squad 6x";
+			vehicle = "O_APC_Tracked_02_cannon_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};
+		};
+
 		class Ifrit_HMG
 		{
 			unitName = "Ifrit HMG";
 			vehicle = "O_MRAP_02_HMG_F";
-			units[] = {"crew", "crew", "crew"};
+			units[] = {"ftl", "rif", "rif"};
+		};
+
+		class Tempest_Reinforcements
+		{
+			unitName = "Tempest Transport + Section 9x";
+			vehicle = "O_Truck_03_covered_F";
+			units[] = {"rif", "rif"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "med", "mk", "rif", "rif", "rif"};
 		};
 	};
 
@@ -206,13 +246,13 @@ class CA_ZeusUI_Units
 			unitName = "INDFOR Fireteam 4x";
 			units[] = {"ftl", "ar", "lat", "rif"};
 		};
-		
+
 		class Squad_6x
 		{
 			unitName = "INDFOR Squad 6x";
 			units[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};	// This spawns a full 6-man fireteam. You can have as many or as few units in a squad as you want.
 		};
-		
+
 		class Section_9x
 		{
 			unitName = "INDFOR Section 9x";
@@ -230,7 +270,7 @@ class CA_ZeusUI_Units
 			unitName = "INDFOR AR Team";
 			units[] = {"aar", "ar"};
 		};
-		
+
 		class MK_Team
 		{
 			unitName = "INDFOR MK Team";
@@ -258,6 +298,14 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class AFV4_Gorgon_Reinforcements
+		{
+			unitName = "AFV-4 Gorgon + Squad 6x";
+			vehicle = "I_APC_Wheeled_03_cannon_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};
+		};
+
 		class FV720_Mora
 		{
 			unitName = "FV-720 Mora";
@@ -265,11 +313,27 @@ class CA_ZeusUI_Units
 			units[] = {"crew", "crew", "crew"};
 		};
 
+		class FV720_Mora_Reinforcements
+		{
+			unitName = "FV-720 Mora + Squad 6x";
+			vehicle = "I_APC_tracked_03_cannon_F";
+			units[] = {"crew", "crew", "crew"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "rif", "mk"};
+		};
+
 		class Strider_HMG
 		{
 			unitName = "Strider HMG";
 			vehicle = "I_MRAP_03_hmg_F";
-			units[] = {"crew", "crew", "crew"};
+			units[] = {"ftl", "rif", "rif"};
+		};
+
+		class Zamak_Reinforcements
+		{
+			unitName = "Zamak Transport + Section 9x";
+			vehicle = "I_Truck_02_covered_F";
+			units[] = {"rif", "rif"};
+			reinforcements[] = {"ftl", "ar", "aar", "lat", "med", "mk", "rif", "rif", "rif"};
 		};
 	};
 };


### PR DESCRIPTION
adds option to add reinforcement squad to the spawner config. Vehicles with reinforcements automatically get a TR Unload waypoint and the reinforcements get a Move waypoint, in front of the spawn to be dragged wherever needed. Vehicles without a gunner get a move waypoint at spawn after the TR Unload waypoint (this does not work consistently).
Already tested on dedi.