### PR TITLE
AI identities rework

### DIFF
--- a/components/gearScript/fn_assignGear.sqf
+++ b/components/gearScript/fn_assignGear.sqf
@@ -103,8 +103,12 @@ if (isPlayer _unit) then
 }
 else
 {
-    if (_unit isKindOf "CAManBase") then
-    {
-        [_unit, _gearVariant] remoteExec ["f_fnc_applyFactionIdentity"];
-    };
+    #ifdef ENABLE_IDENTITY_REPLACEMENT
+
+	if (_unit isKindOf "CAManBase") then
+	{
+	    [_unit, _gearVariant] call f_fnc_applyFactionIdentity;
+	};
+
+    #endif
 };

--- a/components/identity/fn_applyAllUnitIdentities.sqf
+++ b/components/identity/fn_applyAllUnitIdentities.sqf
@@ -1,0 +1,36 @@
+/* --------------------------------------------------------------------------------------------------------------------
+	Author:	 Cre8or
+	Description:
+		(Re)applies the identities on all existing AI units.
+		Called once upon mission initialisation / JIP.
+	Arguments:
+		(none)
+	Returns:
+		(nothing)
+-------------------------------------------------------------------------------------------------------------------- */
+
+#include "macros.hpp";
+
+
+
+
+
+// Set up some variables
+private ["_identity"];
+
+
+
+
+
+// Iterate over all existing units
+{
+	_identity = _x getVariable ["f_var_identity", ""];
+
+	if (_identity != "") then {
+		[_x, _identity] call f_fnc_applyIdentity;
+	};
+
+} forEach (allUnits select {
+	!isPlayer _x
+	and {alive _x}
+});

--- a/components/identity/fn_applyExistingUnitIdentities.sqf
+++ b/components/identity/fn_applyExistingUnitIdentities.sqf
@@ -28,9 +28,6 @@ private ["_identity"];
 
 	if (_identity != "") then {
 		[_x, _identity] call f_fnc_applyIdentity;
-
-		systemChat format ["Handled %1", name _x];
-		diag_log format ["[CRE] Handled %1", name _x];
 	};
 
 } forEach (

--- a/components/identity/fn_applyExistingUnitIdentities.sqf
+++ b/components/identity/fn_applyExistingUnitIdentities.sqf
@@ -28,9 +28,14 @@ private ["_identity"];
 
 	if (_identity != "") then {
 		[_x, _identity] call f_fnc_applyIdentity;
+
+		systemChat format ["Handled %1", name _x];
+		diag_log format ["[CRE] Handled %1", name _x];
 	};
 
-} forEach (allUnits select {
-	!isPlayer _x
-	and {alive _x}
-});
+} forEach (
+	allDeadMen +
+	(allUnits select {
+		!isPlayer _x
+	})
+);

--- a/components/identity/fn_applyFactionIdentity.sqf
+++ b/components/identity/fn_applyFactionIdentity.sqf
@@ -18,4 +18,6 @@ if (_sideName isEqualTo "") then
 
 private _identity = GET_FACTION_IDENTITY_DYNAMIC(_sideName);
 
-[_unit, _identity] call f_fnc_applyIdentity;
+_unit setVariable ["f_var_identity", _identity, true];
+
+[_unit, _identity] remoteExecCall ["f_fnc_applyIdentity", 0, false];

--- a/components/identity/fn_applyIdentity.sqf
+++ b/components/identity/fn_applyIdentity.sqf
@@ -8,8 +8,6 @@
 
 params ["_unit", "_identity"];
 
-_unit setVariable ["f_var_identity", _identity, true];
-
 _speakers = GET_SPEAKERS_FOR_IDENTITY_DYNAMIC(_identity);
 _faces = GET_FACES_FOR_IDENTITY_DYNAMIC(_identity);
 _names = GET_NAMES_FOR_IDENTITY_DYNAMIC(_identity);

--- a/components/identity/functions.hpp
+++ b/components/identity/functions.hpp
@@ -4,4 +4,5 @@ class identity
     class applyFactionIdentity{};
     class applyIdentity{};
     class generateName{};
+    class applyAllUnitIdentities{};
 };

--- a/components/identity/functions.hpp
+++ b/components/identity/functions.hpp
@@ -1,8 +1,8 @@
 class identity
 {
     file = "components\identity";
+    class applyExistingUnitIdentities{};
     class applyFactionIdentity{};
     class applyIdentity{};
     class generateName{};
-    class applyAllUnitIdentities{};
 };

--- a/components/miscShared/fn_factionToSideName.sqf
+++ b/components/miscShared/fn_factionToSideName.sqf
@@ -1,6 +1,8 @@
 
 params ["_faction"];
 
+_faction = toLower _faction;	// "in" compares case-sensitive, meaning {"BLU_F" in ["blu_f"]} returns false.
+				// We don't want this check to fail though, so let's ignore the casing instead.
 _identity = _faction;
 
 

--- a/configuration/identities/identityAssignment.sqf
+++ b/configuration/identities/identityAssignment.sqf
@@ -12,8 +12,8 @@
 
 BEGIN_IDENTITY_ASSIGNMENT;
 
-SET_FACTION_IDENTITY(opfor,british);
-SET_FACTION_IDENTITY(blufor,asian);
+SET_FACTION_IDENTITY(opfor,iranian);
+SET_FACTION_IDENTITY(blufor,american);
 SET_FACTION_IDENTITY(indfor,greek);
-SET_FACTION_IDENTITY(guerrilla,russian);
-SET_FACTION_IDENTITY(civilian,french);
+SET_FACTION_IDENTITY(guerrilla,greek);
+SET_FACTION_IDENTITY(civilian,greek);

--- a/configuration/identities/identityAssignment.sqf
+++ b/configuration/identities/identityAssignment.sqf
@@ -6,14 +6,14 @@
 
     For example:
     SET_FACTION_IDENTITY(opfor,british);
-    
+
 */
 
 
 BEGIN_IDENTITY_ASSIGNMENT;
 
-SET_FACTION_IDENTITY(opfor,iranian);
-SET_FACTION_IDENTITY(blufor,american);
+SET_FACTION_IDENTITY(opfor,british);
+SET_FACTION_IDENTITY(blufor,asian);
 SET_FACTION_IDENTITY(indfor,greek);
-SET_FACTION_IDENTITY(guerrilla,greek);
-SET_FACTION_IDENTITY(civilian,greek);
+SET_FACTION_IDENTITY(guerrilla,russian);
+SET_FACTION_IDENTITY(civilian,french);

--- a/configuration/identityReplacement.hpp
+++ b/configuration/identityReplacement.hpp
@@ -9,5 +9,5 @@
 */
 
 // Enables identity replacements for all units except for players.
-// To disable identity replacements for all units, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_IDENTITY_REPLACEMENT 1
+// To disable identity replacements for all units, comment-out or delete the line below.
+#define ENABLE_IDENTITY_REPLACEMENT

--- a/startup/components/groups/clientStartupGroup.sqf
+++ b/startup/components/groups/clientStartupGroup.sqf
@@ -49,6 +49,6 @@ INIT_COMPONENT(viewDistanceEditor)
 // Identity replacements
 #ifdef ENABLE_IDENTITY_REPLACEMENT
 
-RUN_FUNC_ONCE(f_fnc_applyAllUnitIdentities)
+RUN_FUNC_ONCE(f_fnc_applyExistingUnitIdentities)
 
 #endif

--- a/startup/components/groups/clientStartupGroup.sqf
+++ b/startup/components/groups/clientStartupGroup.sqf
@@ -44,3 +44,11 @@ INIT_COMPONENT(gravestones)
 INIT_COMPONENT(viewDistanceEditor)
 
 #endif
+
+
+// Identity replacements
+#ifdef ENABLE_IDENTITY_REPLACEMENT
+
+RUN_FUNC_ONCE(f_fnc_applyAllUnitIdentities)
+
+#endif


### PR DESCRIPTION
Fixes https://github.com/Bubbus/F3_CA_BUB/issues/51.

- Reworked AI identities to be applied locally, rather than via `remoteExec` (reduces network traffic)
- Added a function that (re)applies all custom AI identities on existing (spawned) units when the client initialises; this can either happen on mission init or JIP
- Implemented the `ENABLE_IDENTITY_REPLACEMENT` config macro, allowing mission makers to turn the component on or off