### PR TITLE
Macro-toggles cleanup

### DIFF
--- a/components/cbaSettings/settings.sqf
+++ b/components/cbaSettings/settings.sqf
@@ -50,11 +50,11 @@
 	#include "spectate_full.sqf"
 
 #endif
-	
+
 
 //Logistics
 
-#ifdef CA2_LOGISTICS 1
+#ifdef CA2_LOGISTICS
 
 	#include "logistics_settings.sqf"
 
@@ -67,7 +67,3 @@
 	#include "acre_settings.sqf"
 
 #endif
-
-
-
-

--- a/configuration/aceActions.hpp
+++ b/configuration/aceActions.hpp
@@ -1,12 +1,12 @@
 
 // Enables inventory ACE action.
-// To disable the inventory action, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_INVENTORY_ACTION 1
+// To disable the inventory action, comment-out or delete the line below.
+#define ENABLE_INVENTORY_ACTION
 
 // Enables unflip ACE action.
-// To disable the unflip action, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_UNFLIP_ACTION 1
+// To disable the unflip action, comment-out or delete the line below.
+#define ENABLE_UNFLIP_ACTION
 
 // Enables push ACE action for boats.
-// To disable the unflip action, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_PUSH_BOATS_ACTION 1
+// To disable the unflip action, comment-out or delete the line below.
+#define ENABLE_PUSH_BOATS_ACTION

--- a/configuration/cbaSettings.hpp
+++ b/configuration/cbaSettings.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 	Author:	Joecuronium
 	Description:
 		This file allows you to enable different addon settings. Be sure to only enable one per category.
@@ -14,15 +14,15 @@
 
 // CA Medical settings (Reopening ON, 80% slower reopening).
 // To enable this, uncomment the line below.
-#define CA_MEDICAL_ADVANCED_80 1
+#define CA_MEDICAL_ADVANCED_80
 
 // CA Medical settings (Reopening ON, 95% slower reopening).
 // To enable this, uncomment the line below.
-// #define CA_MEDICAL_ADVANCED_95 1
+// #define CA_MEDICAL_ADVANCED_95
 
 // CA Medical settings (Reopening OFF).
 // To enable this, uncomment the line below.
-// #define CA_MEDICAL_BASIC 1
+// #define CA_MEDICAL_BASIC
 
 
 /*
@@ -31,20 +31,20 @@
 */
 
 // CA2 downtime spectate cam modes. If this setting is enabled, unconscious players are restricted to 1PP and 3PP, dead players have all spectate modes.
-// To disable this, comment-out or delete the line below INSTEAD of setting it to 0.
-#define CA2_SPECTATE_LIMITED 1
+// To disable this, comment-out or delete the line below.
+#define CA2_SPECTATE_LIMITED
 
 // CA2 downtime spectate cam modes. If this setting is enabled, all spectate modes will be available to unconscious and dead players.
-// To disable this, comment-out or delete the line below INSTEAD of setting it to 0. Be sure to only uncomment one line per category.
-// #define CA2_SPECTATE_FULL 1
+// To disable this, comment-out or delete the line below. Be sure to only uncomment one line per category.
+// #define CA2_SPECTATE_FULL
 
 
 /*
 	LOGISTICS SETTINGS
 */
 // CA2 ideal logistics settings (this will set-up logistics for best use with the CA2 built-in logi-suite).
-// To disable this, comment-out or delete the line below INSTEAD of setting it to 0.
-#define CA2_LOGISTICS 1
+// To disable this, comment-out or delete the line below.
+#define CA2_LOGISTICS
 
 
 /*
@@ -52,6 +52,5 @@
 */
 
 // ACRE terrain loss.
-// To enable terrain-loss, comment-out or delete the line below INSTEAD of setting it to 0.
-#define DISABLE_ACRE_TERRAIN_LOSS 1
-
+// To enable terrain-loss, comment-out or delete the line below.
+#define DISABLE_ACRE_TERRAIN_LOSS

--- a/configuration/debug.hpp
+++ b/configuration/debug.hpp
@@ -1,3 +1,2 @@
-
 // Enables debugging
-// #define ENABLE_DEBUG 1
+// #define ENABLE_DEBUG

--- a/configuration/gravestones.hpp
+++ b/configuration/gravestones.hpp
@@ -17,20 +17,20 @@
 
 // Enables the gravestone corpse-manager.
 // When disabled, the default Arma 3 corpse manager will be used instead.
-// To disable the gravestone corpse-manager, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_GRAVESTONE_CORPSE_MANAGER 1
+// To disable the gravestone corpse-manager, comment-out or delete the line below.
+#define ENABLE_GRAVESTONE_CORPSE_MANAGER
 
 // Enables the gravestones for old corpses.
-// To disable gravestones, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_GRAVESTONES 1
+// To disable gravestones, comment-out or delete the line below.
+#define ENABLE_GRAVESTONES
 
 // Enable a priority list for important corpses (such as players).  These corpses will only be removed when there is no other choice.
-// To disable the priority list, comment-out or delete the line below INSTEAD of setting it to 0.
-#define GRAVESTONES_USE_PRIORITY_LIST 1
+// To disable the priority list, comment-out or delete the line below.
+#define GRAVESTONES_USE_PRIORITY_LIST
 
 // Enables gravestones only for important corpses (such as players).  Deletion rules remain the same for other corpses, but they will not receive a gravestone.
-// To allow gravestones for all units, comment-out or delete the line below INSTEAD of setting it to 0.
-//#define GRAVESTONES_ALLOW_PRIORITY_ONLY 1
+// To allow gravestones for all units, comment-out or delete the line below.
+//#define GRAVESTONES_ALLOW_PRIORITY_ONLY
 
 // The amount of corpses which can exist before gravestones start to appear.
 #define MAX_CORPSES_BEFORE_GRAVESTONES 20

--- a/configuration/identityReplacement.hpp
+++ b/configuration/identityReplacement.hpp
@@ -9,5 +9,5 @@
 */
 
 // Enables identity replacements for all units except for players.
-// To disable identity replacements for all units, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_IDENTITY_REPLACEMENT 1
+// To disable identity replacements for all units, comment-out or delete the line below.
+#define ENABLE_IDENTITY_REPLACEMENT

--- a/configuration/insignia.hpp
+++ b/configuration/insignia.hpp
@@ -27,5 +27,5 @@
 */
 
 // Enables the usage of the Advanced Insignia mode.
-// To disable Advanced Insignia mode for all units, comment-out or delete the line below INSTEAD of setting it to 0.
-//#define ENABLE_ADVANCED_INSIGNIA 1
+// To disable Advanced Insignia mode for all units, comment-out or delete the line below.
+//#define ENABLE_ADVANCED_INSIGNIA

--- a/configuration/killTracking.hpp
+++ b/configuration/killTracking.hpp
@@ -1,7 +1,7 @@
 
 // Enables kill-logging.
-// To disable kill-logging, comment-out or delete the line below INSTEAD of setting it to 0.
-// #define ENABLE_KILL_TRACKING 1
+// To disable kill-logging, comment-out or delete the line below.
+// #define ENABLE_KILL_TRACKING
 
 // Name to use for the kill-log.  This separates the kill-logs for each mission, so it should be unique.
 #define KILL_LOG_NAME TestMission

--- a/configuration/mapMarkers.hpp
+++ b/configuration/mapMarkers.hpp
@@ -1,12 +1,11 @@
+// To disable squad markers on the map, comment-out or delete the line below.
+#define ENABLE_SQUAD_MARKERS
 
-// To disable squad markers on the map, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_SQUAD_MARKERS 1
+// To disable fireteam member markers on the map, comment-out or delete the line below.
+#define ENABLE_FIRETEAM_MARKERS
 
-// To disable fireteam member markers on the map, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_FIRETEAM_MARKERS 1
+// To hide AI squads on the map, comment-out or delete the line below.
+#define SHOW_NPC_SQUADS
 
-// To hide AI squads on the map, comment-out or delete the line below INSTEAD of setting it to 0.
-#define SHOW_NPC_SQUADS 1
-
-// To disable squadmarker MicroDAGR integration, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_MICRODAGR_SQUADMARKERS 1
+// To disable squadmarker MicroDAGR integration, comment-out or delete the line below.
+#define ENABLE_MICRODAGR_SQUADMARKERS

--- a/configuration/objectScaling.hpp
+++ b/configuration/objectScaling.hpp
@@ -24,5 +24,5 @@
 
 
 
-// To disable object scaling support, comment-out or delete the line below INSTEAD of setting it to 0.
-// #define ENABLE_SCALE_SUPPORT 1
+// To disable object scaling support, comment-out or delete the line below.
+// #define ENABLE_SCALE_SUPPORT

--- a/configuration/sogConfig.hpp
+++ b/configuration/sogConfig.hpp
@@ -5,4 +5,4 @@ This file allows the missionmaker to define the mission as one using the S.O.G. 
 */
 
 //Uncomment the line below to activate this feature
-//#define CA2_SOGMISSION 1
+//#define CA2_SOGMISSION

--- a/configuration/viewDistanceEditor.hpp
+++ b/configuration/viewDistanceEditor.hpp
@@ -1,13 +1,13 @@
 
 // Enable players to edit their view distance settings via the ACE self-interact menu.
-// To disable the view-distance editor, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_VIEWDISTANCE_EDITOR 1
+// To disable the view-distance editor, comment-out or delete the line below.
+#define ENABLE_VIEWDISTANCE_EDITOR
 
 // When enabled, only units with the following variable can use the view-distande editor.  Use for pilots, snipers, tankers etc...
 // this setVariable ["f_var_allowViewDistanceEditing", true, true];
-// To allow everyone to edit view distance, comment-out or delete the line below INSTEAD of setting it to 0.
-// #define VIEWDISTANCE_EDITOR_WHITELISTING 1
+// To allow everyone to edit view distance, comment-out or delete the line below.
+// #define VIEWDISTANCE_EDITOR_WHITELISTING
 
 // Enable players to access the lowest-quality terrain detail setting.  This can help with frame-rate, but also disables grass and can therefore be a huge gameplay advantage.
-// To prevent players from disabling grass, comment-out or delete the line below INSTEAD of setting it to 0.
-#define ENABLE_LOWEST_TERRAIN_DETAIL 1
+// To prevent players from disabling grass, comment-out or delete the line below.
+#define ENABLE_LOWEST_TERRAIN_DETAIL


### PR DESCRIPTION
Summary of changes:
- Cleaned up most (if not all) instances of macro definitions where a value was defined, but not needed
- Fixed an incorrect preprocessor directive in `components\cbaSettings\settings.sqf` (possibly a typo?)

Closes https://github.com/Bubbus/F3_CA_BUB/issues/56.

**NOTE:** While working on this, I came across an unreferenced macro (`GRAVESTONES_USE_PRIORITY_LIST`):
https://github.com/Bubbus/F3_CA_BUB/blob/289c06b675c44b9c9186c243863fd263e6e730c9/configuration/gravestones.hpp#L27-L29

I'd assume the corresponding feature is still in development, but I'm out of the loop. Should I leave it in, or remove it?