### PR TITLE
[Bugfix] Fix ending dialog population breaking on double defined entries

### DIFF
--- a/components/zeus_ui/fn_endingDialog.sqf
+++ b/components/zeus_ui/fn_endingDialog.sqf
@@ -3,12 +3,16 @@
 private _endingArray = "true" configClasses (missionConfigFile >> "CfgDebriefing"); //Gather all endings
 
 private _endingClasses = [];
-private _endingTitles = [];
+private _endingNames = [];
 
 {
 	private _title = getText (_x >> "Title");
 
-	_endingTitles pushBackUnique _title;
+	private _subtitle = getText (_x >> "subtitle");
+
+	private _name = _title + " - " + _subtitle;
+
+	_endingNames pushBackUnique _name;
   
 	private _class = configName (_x);
   
@@ -19,7 +23,7 @@ private _endingTitles = [];
 
 ["Ending Dialog",
 	[
-		["COMBO", "Choose Ending:",[_endingClasses, _endingTitles,0]]
+		["COMBO", "Choose Ending:",[_endingClasses, _endingNames,0]]
 	],
 	{
 		params ["_dialogValues"];


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
Fix an underlying issue that caused the ending dialogue population script to break if the same ending title was used on multiple endings. Also makes the dialogue easier to follow by adding the subtitle in the preview.

### Release Notes
Fixed ending dialogue population breaking on double defined entries

## IMPORTANT

- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

