### PR TITLE
[Feature] - Disable ACE advanced car damage by default.

### DIFF
--- a/components/cbaSettings/ace_vic_settings.sqf
+++ b/components/cbaSettings/ace_vic_settings.sqf
@@ -1,0 +1,3 @@
+force ace_vehicle_damage_enabled = false;
+force ace_vehicle_damage_removeAmmoDuringCookoff = false;
+force ace_vehicle_damage_enableCarDamage = false;

--- a/components/cbaSettings/ace_vic_settings.sqf
+++ b/components/cbaSettings/ace_vic_settings.sqf
@@ -1,3 +1,1 @@
-force ace_vehicle_damage_enabled = false;
-force ace_vehicle_damage_removeAmmoDuringCookoff = false;
 force ace_vehicle_damage_enableCarDamage = false;

--- a/components/cbaSettings/settings.sqf
+++ b/components/cbaSettings/settings.sqf
@@ -68,9 +68,9 @@
 
 #endif
 
-//ACE Adv. Vehicle Damage
+//ACE Adv. Car Damage
 
-#ifdef DISABLE_ACE_VEHICLE_DAMAGE
+#ifdef DISABLE_ACE_CAR_DAMAGE
 
 	#include "ace_vic_settings.sqf"
 

--- a/components/cbaSettings/settings.sqf
+++ b/components/cbaSettings/settings.sqf
@@ -67,3 +67,11 @@
 	#include "acre_settings.sqf"
 
 #endif
+
+//ACE Adv. Vehicle Damage
+
+#ifdef DISABLE_ACE_VEHICLE_DAMAGE
+
+	#include "ace_vic_settings.sqf"
+
+#endif

--- a/configuration/cbaSettings.hpp
+++ b/configuration/cbaSettings.hpp
@@ -60,6 +60,6 @@
 	ACE SETTINGS
 */
 
-// ACE advanced vehicle damage.
-// To enable advanced vehicle damage, comment-out or delete the line below.
-#define DISABLE_ACE_VEHICLE_DAMAGE
+// ACE advanced car damage.
+// To enable advanced car damage, comment-out or delete the line below.
+#define DISABLE_ACE_CAR_DAMAGE

--- a/configuration/cbaSettings.hpp
+++ b/configuration/cbaSettings.hpp
@@ -54,3 +54,12 @@
 // ACRE terrain loss.
 // To enable terrain-loss, comment-out or delete the line below.
 #define DISABLE_ACRE_TERRAIN_LOSS
+
+
+/*
+	ACE SETTINGS
+*/
+
+// ACE advanced vehicle damage.
+// To enable advanced vehicle damage, comment-out or delete the line below.
+#define DISABLE_ACE_VEHICLE_DAMAGE


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Disable ACE advanced car damage by default.
- Add an option into the CBA settings config file to re-enable if desired.

### Release Notes
Disable ACE advanced car damage by default and added an option into the CBA settings config file to re-enable if desired.

## IMPORTANT

- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

