### PR TITLE
[Improve Gearscript] Resupply crates now have space to drop stuff

### DIFF
--- a/components/gearScript/fn_applyLoadout.sqf
+++ b/components/gearScript/fn_applyLoadout.sqf
@@ -35,9 +35,12 @@ if (_typeofUnit find "crate_" == 0) exitWith
 
         } forEach _crateArray;
 
+        //Add Space to drop stuff into the box
         private _oldLoad = loadAbs _unit;
 
-        _unit setMaxLoad (_oldLoad * 1.25);
+        private _newLoad = _oldLoad * 1.25;
+
+        [_unit, _newLoad] remoteExecCall ["setMaxLoad", 2];
 
     }
     else

--- a/components/gearScript/fn_applyLoadout.sqf
+++ b/components/gearScript/fn_applyLoadout.sqf
@@ -35,6 +35,10 @@ if (_typeofUnit find "crate_" == 0) exitWith
 
         } forEach _crateArray;
 
+        private _oldLoad = loadAbs _unit;
+
+        _unit setMaxLoad (_oldLoad * 1.25);
+
     }
     else
     {


### PR DESCRIPTION

### Pull Request Description
**When merged this pull request will:**
Fix #107 
Make Gearscript automatically add 25% more load capacity over the assigned gear on all gearscripted crates
Not tested in MP but there is no way this won't work, right?


### Release Notes
Gearscript automatically adds 25% more load capacity over the assigned gear on all gearscripted crates


## IMPORTANT

- [ ] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [ ] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [ ] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

