### PR TITLE
[FIX] Zeus being unable to properly update crate gear via module

### DIFF
--- a/components/gearScript/zen/fn_zen_createSupplyCrate_performAction.sqf
+++ b/components/gearScript/zen/fn_zen_createSupplyCrate_performAction.sqf
@@ -25,5 +25,5 @@ if (isNull _unit) then
 else
 {
     ["Replacing inventory of '%1' with contents of '%2'.", _unit, _chosenGear] call zen_common_fnc_showMessage;
-    [_chosenGear, _unit, _chosenFaction] remoteExecCall ["f_fnc_assignGear", _unit];
+    [_chosenGear, _unit, _chosenFaction] remoteExec ["f_fnc_assignGear", _unit];
 };

--- a/components/gearScript/zen/fn_zen_createSupplyCrate_performAction.sqf
+++ b/components/gearScript/zen/fn_zen_createSupplyCrate_performAction.sqf
@@ -25,5 +25,5 @@ if (isNull _unit) then
 else
 {
     ["Replacing inventory of '%1' with contents of '%2'.", _unit, _chosenGear] call zen_common_fnc_showMessage;
-    [_chosenGear, _unit, _chosenFaction] call f_fnc_assignGear;
+    [_chosenGear, _unit, _chosenFaction] remoteExecCall ["f_fnc_assignGear", _unit];
 };


### PR DESCRIPTION


### Pull Request Description
**When merged this pull request will:**
Properly allow zeus to use the logistics module when assigning gear to a already present crate

### Release Notes
fixed edgecase of Zeus being unable to assign gear to crates in certain cases

## IMPORTANT

- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

