### PR TITLE
[Improve] Changed default vehicle lock to "Locked for players" for framework sp…

### DIFF
--- a/components/spawnNpcs/fn_spawnVehicleGroup.sqf
+++ b/components/spawnNpcs/fn_spawnVehicleGroup.sqf
@@ -21,7 +21,7 @@ params ["_unitarray", "_position", "_vehicletype", ["_faction",""], ["_side", f_
 
 _reinforcementsExist = ((count _reinforcementarray) > 0);
 
-_spawnVicArray = [_position, _vehicletype, 0, _dir] call f_fnc_spawnVehicle;
+_spawnVicArray = [_position, _vehicletype, 3, _dir] call f_fnc_spawnVehicle;
 _group = [_unitarray, _position, _faction, _side, _suppressive, _guerrilla, _enableAdvancedAI] call f_fnc_spawnGroup;
 
 _vehicle = _spawnVicArray select 0;


### PR DESCRIPTION
…awned vics

### Pull Request Description
**When merged this pull request will:**
Lock vehicles spawned by the framework-spawner for players

### Release Notes
Vehicles will now be locked by default by default when spawned by the framework-spawner

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

