### PR TITLE
[Bugfix] Compatability for new ACE gearstrings

### DIFF
--- a/components/gearScript/fn_applyLoadoutModifications.sqf
+++ b/components/gearScript/fn_applyLoadoutModifications.sqf
@@ -4,7 +4,7 @@
 
 params ["_loadout"];
 
-if (count _loadout < 3) then
+if (count _loadout != 10) then
 {
 	_loadout = _loadout#0;
 };

--- a/components/gearScript/fn_applyLoadoutModifications.sqf
+++ b/components/gearScript/fn_applyLoadoutModifications.sqf
@@ -4,6 +4,11 @@
 
 params ["_loadout"];
 
+if (count _loadout < 3) then
+{
+	_loadout = _loadout#0;
+};
+
 _uniform = _loadout#3;
 _vest = _loadout#4;
 _backpack = _loadout#5;

--- a/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
+++ b/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
@@ -12,6 +12,8 @@ if (typeName _contents isEqualTo "STRING") exitWith
 	[_faction, _unitName, _contents] call f_fnc_setGunbagVariableState;
 };
 
+_contents = _contents#0;
+
 if (count _contents < 1) then {throw format ["_contents for gunbag contents is empty. (unit %1, side %2).", _unitName, _faction]};
 
 private _rifle = _contents # 0;

--- a/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
+++ b/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
@@ -12,7 +12,10 @@ if (typeName _contents isEqualTo "STRING") exitWith
 	[_faction, _unitName, _contents] call f_fnc_setGunbagVariableState;
 };
 
-_contents = _contents#0;
+if (count _contents != 10) then
+{
+	_contents = _contents#0;
+};
 
 if (count _contents < 1) then {throw format ["_contents for gunbag contents is empty. (unit %1, side %2).", _unitName, _faction]};
 


### PR DESCRIPTION
gunbag compat also done

### Pull Request Description
**When merged this pull request will:**
Fix the issue that new ACE arsenal exports do not work with the framework
Maintain compat with the old string system as well to facilitate reruns
This is a rough hotfix, there is probably a better way
Gunbag compat also added for develop branch

### Release Notes
Fix the issue that new ACE arsenal exports do not work with the framework

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

