### PR TITLE
[Improve] Fix PAK Stitch Exploit Pending ACE PR Merge

### DIFF
--- a/components/functions.hpp
+++ b/components/functions.hpp
@@ -48,6 +48,16 @@ class ace_medical_feedback
 	};
 };
 
+
+class ace_medical_status
+{
+	class overrides
+	{
+		file = "components\medical";
+		class isInStableCondition{};
+	}
+};
+
 class ace_gunbag
 {
 	class overrides

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -31,7 +31,7 @@ if (_unit getVariable ["ace_medical_inPain", false]) exitWith {false};
 private _hasUnstitchedWounds = (_unit getVariable ["ace_medical_bandagedWounds", []]) isNotEqualTo [];
 
 // If there are any bandageable wounds that are open, there are open wounds. _x select 3 > 0 Discards any non-bleeding wounds, such as bruises.
-private _hasOpenWounds = (_unit getVariable ["ace_medical_openWounds", []] findIf {(_x select 2 > 0) and (_x select 3 > 0)} ) != -1;
+private _hasOpenWounds = (_unit getVariable ["ace_medical_openWounds", []] findIf {(_x select 2 > 0) and {(_x select 3 > 0)}} ) != -1;
 
 if (_hasOpenWounds or _hasUnstitchedWounds) exitWith {false};
 

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -17,7 +17,7 @@ if (!alive _unit
 
 // If they have insufficient blood, we cannot PAK.
 private _requiredBloodVolume = _defaultBloodVolume * (_minBloodPAK / 100);
-if ((_unit getVariable ["ace_medical_bloodVolume", 0])  < _requiredBloodVolume) exitWith {false};
+if ((_unit getVariable ["ace_medical_bloodVolume", 0]) < _requiredBloodVolume) exitWith {false};
 
 // Unit must not have fractures
 if((_unit getVariable ["ace_medical_fractures", []]) isNotEqualTo []) exitWith {false};

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -30,7 +30,7 @@ if (_unit getVariable ["ace_medical_inPain", false]) exitWith {false};
 private _hasUnstitchedWounds = (_unit getVariable ["ace_medical_bandagedWounds", []]) isNotEqualTo [];
 
 // If there are any bandageable wounds that are open, there are open wounds. _x select 3 > 0 Discards any non-bleeding wounds, such as bruises.
-private _hasOpenWounds = (((_unit getVariable ["ace_medical_openWounds", []] findIf {_x select 2 > 0 && _x select 3 > 0} ) != -1 ));
+private _hasOpenWounds = (_unit getVariable ["ace_medical_openWounds", []] findIf {(_x select 2 > 0) and (_x select 3 > 0)} ) != -1;
 
 if (_hasOpenWounds or _hasUnstitchedWounds) exitWith {false};
 

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -21,7 +21,7 @@ if ((_unit getVariable ["ace_medical_bloodVolume", 0]) < _requiredBloodVolume) e
 
 // Unit must not have fractures
 private _fractures = _unit getVariable ["ace_medical_fractures", []];
-if ((_fractures findIf {_x isNotEqualTo 0}) != -1) exitWith {false};
+if ((_fractures findIf {_x isEqualTo 1}) != -1) exitWith {false};
 
 // Unit must not be in pain
 if (_unit getVariable ["ace_medical_inPain", false]) exitWith {false};

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -1,0 +1,43 @@
+
+if (isNil "f_var_originalFunction_isInStableCondition") then
+{
+    // Why isn't this easier to do in SQF?  Why does it have to be so brittle?  what the christ
+    f_var_originalFunction_isInStableCondition = compile preprocessFileLineNumbers "z\ace\addons\medical_status\functions\fnc_isInStableCondition.sqf";
+};
+
+params ["_unit"];
+
+// Hard-coding variables that would otherwise be in CBA and/or I can't seem to retrieve (defaultBloodVolume. These should be safe to hard-code.
+private _minHeartRatePAK = 40;
+private _minBloodPAK = 0.85;
+private _defaultBloodVolume = 6;
+
+
+// If the unit is dead, unconscious, bleeding, or below minimum heart rate, we cannot PAK.
+if (!alive _unit
+    || {(_unit getVariable ["ACE_isUnconscious", false])}
+    || {(_unit getVariable ["ace_medical_woundBleeding", 0]) > 0}
+    || {(_unit getVariable ["ace_medical_heartRate", 0]) < _minHeartRatePAK}
+) exitWith {false};
+
+// If they have insufficient blood, we cannot PAK.
+private _requiredBloodVolume = _defaultBloodVolume * (_minBloodPAK / 100);
+if ((_unit getVariable ["ace_medical_bloodVolume", 0])  < _requiredBloodVolume) exitWith {false};
+
+// Unit must not have fractures
+if((_unit getVariable ["ace_medical_fractures", []]) isNotEqualTo []) exitWith {false};
+
+// Unit must not be in pain
+if ((_unit getVariable ["ace_medical_inPain", false])) exitWith {false};
+
+
+// If there are any bandaged wounds, they have not been stitched.
+private _hasUnstitchedWounds = (_unit getVariable ["ace_medical_bandagedWounds", []]) isNotEqualTo [];
+
+// If there are any bandageable wounds that are open, there are open wounds. _x select 3 > 0 Discards any non-bleeding wounds, such as bruises.
+private _hasOpenWounds = (((_unit getVariable ["ace_medical_openWounds", []] findIf {_x select 2 > 0 && _x select 3 > 0} ) != -1 ));
+
+if(_hasOpenWounds || _hasUnstitchedWounds) exitWith {false};
+
+
+true

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -32,7 +32,7 @@ private _hasUnstitchedWounds = (_unit getVariable ["ace_medical_bandagedWounds",
 // If there are any bandageable wounds that are open, there are open wounds. _x select 3 > 0 Discards any non-bleeding wounds, such as bruises.
 private _hasOpenWounds = (((_unit getVariable ["ace_medical_openWounds", []] findIf {_x select 2 > 0 && _x select 3 > 0} ) != -1 ));
 
-if(_hasOpenWounds || _hasUnstitchedWounds) exitWith {false};
+if (_hasOpenWounds or _hasUnstitchedWounds) exitWith {false};
 
 
 true

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -23,7 +23,7 @@ if ((_unit getVariable ["ace_medical_bloodVolume", 0])  < _requiredBloodVolume) 
 if((_unit getVariable ["ace_medical_fractures", []]) isNotEqualTo []) exitWith {false};
 
 // Unit must not be in pain
-if ((_unit getVariable ["ace_medical_inPain", false])) exitWith {false};
+if (_unit getVariable ["ace_medical_inPain", false]) exitWith {false};
 
 
 // If there are any bandaged wounds, they have not been stitched.

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -20,7 +20,8 @@ private _requiredBloodVolume = _defaultBloodVolume * (_minBloodPAK / 100);
 if ((_unit getVariable ["ace_medical_bloodVolume", 0]) < _requiredBloodVolume) exitWith {false};
 
 // Unit must not have fractures
-if((_unit getVariable ["ace_medical_fractures", []]) isNotEqualTo []) exitWith {false};
+private _fractures = _unit getVariable ["ace_medical_fractures", []];
+if ((_fractures findIf {_x isNotEqualTo 0}) != -1) exitWith {false};
 
 // Unit must not be in pain
 if (_unit getVariable ["ace_medical_inPain", false]) exitWith {false};

--- a/components/medical/fn_isInStableCondition.sqf
+++ b/components/medical/fn_isInStableCondition.sqf
@@ -1,9 +1,4 @@
 
-if (isNil "f_var_originalFunction_isInStableCondition") then
-{
-    // Why isn't this easier to do in SQF?  Why does it have to be so brittle?  what the christ
-    f_var_originalFunction_isInStableCondition = compile preprocessFileLineNumbers "z\ace\addons\medical_status\functions\fnc_isInStableCondition.sqf";
-};
 
 params ["_unit"];
 


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Resolves #123 by implementing the changes in my pending ACE PR referenced in the issue.
- Requires that a unit meets the following conditions to receive a PAK:
Minimum Blood Level of 85%
Minimum Heart Rate of 40
Patient must have no fractures
Patient must not be in pain
Patient must have no open or bandaged wounds (Must be fully stitched)


### Release Notes
Personal Aid Kits no longer bypass stitching. In order to use a PAK, the patient must meet the following conditions:
- Minimum Blood Level of 85%
- Minimum Heart Rate of 40
- Patient must have no fractures
- Patient must not be in pain
- Patient must have no open or bandaged wounds (Must be fully stitched)


## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.