### PR TITLE
[Hotfix] Stop CBA loadouts propagating through gearscript library without being unwrapped.

### DIFF
--- a/components/gearScript/crateSupport/fn_addBackpacksToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addBackpacksToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addLauncherAmmoToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addLauncherAmmoToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addLauncherToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addLauncherToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addPistolAmmoToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addPistolAmmoToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addPistolToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addPistolToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addRifleAmmoToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addRifleAmmoToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addRifleGrenadesToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addRifleGrenadesToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/crateSupport/fn_addRifleToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addRifleToCrate.sqf
@@ -17,7 +17,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 };
 
 
-_baseVariant = _loadoutVariants select 0;
+_baseVariant = [_loadoutVariants # 0] call f_fnc_normaliseCbaExtendedLoadout;
+_baseVariant = _baseVariant # 0;
 
 if !(typeName _baseVariant == "ARRAY" and {count _baseVariant > 0 and {typeName (_baseVariant select 0) == "ARRAY"}}) exitWith
 {

--- a/components/gearScript/fn_addItemToLoadoutContainer.sqf
+++ b/components/gearScript/fn_addItemToLoadoutContainer.sqf
@@ -29,7 +29,10 @@ if !(isNull _magConfig) then
 };
 
 {    
-    private _container = _x # _containerIndex;    
+    private _cbaLoadout = [_x] call f_fnc_normaliseCbaExtendedLoadout;
+    private _loadout = _cbaLoadout#0;
+
+    private _container = _loadout # _containerIndex;    
     if (_container isNotEqualTo []) then
     {
         private _contents = _container # 1;

--- a/components/gearScript/fn_addLinkedItemToLoadout.sqf
+++ b/components/gearScript/fn_addLinkedItemToLoadout.sqf
@@ -15,7 +15,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 DEBUG_FORMAT3_LOG("[GEARSCRIPT-2]: Removing linked item #%1 from loadout '%2' for side '%3'.",_itemIndex,_unitType,_faction)
 
 {    
-    private _loadout = _x;
+    private _cbaLoadout = [_x] call f_fnc_normaliseCbaExtendedLoadout;
+    private _loadout = _cbaLoadout#0;
 
     private _linkedItems = _loadout#9;
     if (count _linkedItems > _itemIndex) then

--- a/components/gearScript/fn_applyLoadout.sqf
+++ b/components/gearScript/fn_applyLoadout.sqf
@@ -73,15 +73,10 @@ if (_loadoutVariants isEqualTo []) exitWith
 
 
 private _originalLoadout = +(selectRandom _loadoutVariants);
-private _loadout = _originalLoadout;
-private _extendedArray = [];
+_originalLoadout = [_originalLoadout] call f_fnc_normaliseCbaExtendedLoadout;
 
-// Check for CBA extended loadout, unwrap if present.
-if (count _originalLoadout != 10) then
-{
-	_loadout = _originalLoadout#0;
-    _extendedArray = _originalLoadout#1;
-};
+private _loadout = _originalLoadout#0;
+private _extendedArray = _originalLoadout#1;
 
 
 if (count HATS_DYNAMIC(_gearVariant,_typeofUnit) > 0) then

--- a/components/gearScript/fn_normaliseCbaExtendedLoadout.sqf
+++ b/components/gearScript/fn_normaliseCbaExtendedLoadout.sqf
@@ -1,0 +1,11 @@
+params ["_originalLoadout"];
+
+// Check for CBA extended loadout, wrap if bare loadout.
+if (count _originalLoadout == 10) then
+{
+    [_originalLoadout, []]
+}
+else
+{
+    _originalLoadout
+}

--- a/components/gearScript/fn_removeItemFromLoadout.sqf
+++ b/components/gearScript/fn_removeItemFromLoadout.sqf
@@ -41,7 +41,8 @@ private _removeItem =
 };
 
 {    
-    private _loadout = _x;
+    private _cbaLoadout = [_x] call f_fnc_normaliseCbaExtendedLoadout;
+    private _loadout = _cbaLoadout#0;
 
     private _uniform = _loadout#3;
     if (_uniform isNotEqualTo []) then

--- a/components/gearScript/fn_removeLinkedItemFromLoadout.sqf
+++ b/components/gearScript/fn_removeLinkedItemFromLoadout.sqf
@@ -15,7 +15,8 @@ if (_loadoutVariants isEqualTo []) exitWith
 DEBUG_FORMAT3_LOG("[GEARSCRIPT-2]: Removing linked item #%1 from loadout '%2' for side '%3'.",_itemIndex,_unitType,_faction)
 
 {    
-    private _loadout = _x;
+    private _cbaLoadout = [_x] call f_fnc_normaliseCbaExtendedLoadout;
+    private _loadout = _cbaLoadout#0;
 
     private _linkedItems = _loadout#9;
     if (count _linkedItems > _itemIndex) then

--- a/components/gearScript/functions.hpp
+++ b/components/gearScript/functions.hpp
@@ -11,6 +11,7 @@ class gearScript
     class applyLoadout{};
     class assignGear{};
     class createLoadoutLocker{};
+    class normaliseCbaExtendedLoadout{};
     class reapplyGear{};
     class removeItemFromLoadout{};
     class removeLinkedItemFromLoadout{};

--- a/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
+++ b/components/gearScript/gunbag/fn_setGunbagVariableFromArsenalExport.sqf
@@ -12,10 +12,8 @@ if (typeName _contents isEqualTo "STRING") exitWith
 	[_faction, _unitName, _contents] call f_fnc_setGunbagVariableState;
 };
 
-if (count _contents != 10) then
-{
-	_contents = _contents#0;
-};
+_contents = [_contents] call f_fnc_normaliseCbaExtendedLoadout;
+_contents = _contents#0;
 
 if (count _contents < 1) then {throw format ["_contents for gunbag contents is empty. (unit %1, side %2).", _unitName, _faction]};
 


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Fix CBA extended loadouts gumming up the gearscript cogs.

### Release Notes
CBA extended loadouts no longer stop the gearscript machine going brrr

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

