### PR TITLE
[Feature] - Add ACE actions to loadout lockers

### DIFF
--- a/components/gearScript/fn_createLoadoutLocker.sqf
+++ b/components/gearScript/fn_createLoadoutLocker.sqf
@@ -15,58 +15,92 @@ if (_gearVariant isEqualTo "") exitWith {};
 
 if (IS_PLAYER) then
 {
-    _registry = LOADOUT_REGISTRY_DYNAMIC(_gearVariant);
+	_registry = LOADOUT_REGISTRY_DYNAMIC(_gearVariant);
 
-    if (_registry isEqualTo []) exitWith {};
+	if (_registry isEqualTo []) exitWith {};
 
-    _codeTemplate = "['%1', (_this select 1), '%2'] call f_fnc_assignGear;";
+	_codeTemplate = "['%1', (_this select 1), '%2'] call f_fnc_assignGear;";
 
-    {
-        _xCaps = toUpper _x;
+	// Add the base ACE3 category
+	[
+		_locker,
+		0,
+		[],
+		[
+			"cafe3_takeLoadout",
+			"Take Loadout",
+			"",
+			{},
+			{true}
+		] call ace_interact_menu_fnc_createAction
+	] call ace_interact_menu_fnc_addActionToObject;
 
-        if !(_xCaps isEqualTo "DEFAULT") then
-        {
-            _condition = "!(_this getVariable ['f_var_assignGear_running', false])";
+	{
+		_xCaps = toUpper _x;
 
-            if (_xCaps isEqualTo "ZEUS") then
-            {
-                _condition = "!((_this getVariable ['f_var_assignGear_running', false]) or {!(_this getVariable ['f_var_isZeus', false])})";
-            };
+		if !(_xCaps isEqualTo "DEFAULT") then
+		{
+			_condition = "!(_this getVariable ['f_var_assignGear_running', false])";
 
-            _locker addAction
-            [
-                format ["<t color='#999999'>Take loadout:</t> <t color='#ff8800'>%1</t>", _xCaps],
-                format [_codeTemplate, _x, _faction],
-                nil,
-                1.5,
-                false,
-                true,
-                "",
-                _condition,
-                5
-            ];
-        };
+			if (_xCaps isEqualTo "ZEUS") then
+			{
+				_condition = "!((_this getVariable ['f_var_assignGear_running', false]) or {!(_this getVariable ['f_var_isZeus', false])})";
+			};
 
-    } forEach _registry;
+			_locker addAction
+			[
+				format ["<t color='#999999'>Take loadout:</t> <t color='#ff8800'>%1</t>", _xCaps],
+				format [_codeTemplate, _x, _faction],
+				nil,
+				1.5,
+				false,
+				true,
+				"",
+				_condition,
+				5
+			];
+
+			[
+				_locker,
+				0,
+				["cafe3_takeLoadout"],
+				[
+					format ["cafe3_takeLoadout_%1", _xCaps],
+					_xCaps,
+					"",
+					compile format ["_this = [_target, _player];" + _codeTemplate, _x, _faction],
+					compile ("_this = _player;" + _condition)
+				] call ace_interact_menu_fnc_createAction
+			] call ace_interact_menu_fnc_addActionToObject;
+		};
+
+	} forEach _registry;
 
 };
 
 _locker setVariable ["f_var_isLoadoutLocker", true];
 
-
 _bagType = switch (_gearVariant) do
 {
-    case ("blufor"):      {"Land_TentSolar_01_folded_bluewhite_F"};
-    case ("opfor"):       {"Land_TentSolar_01_folded_redwhite_F"};
-    case ("indfor"):      {"Land_TentSolar_01_folded_olive_F"};
-    case ("guerrilla"):   {"Land_TentSolar_01_folded_olive_F"};
-    case ("civilian"):    {"Land_TentSolar_01_folded_sand_F"};
-    default               {"RoadCone_L_F"};
+	case "blufor":    {"Land_TentSolar_01_folded_bluewhite_F"};
+	case "opfor":     {"Land_TentSolar_01_folded_redwhite_F"};
+	case "indfor":    {"Land_TentSolar_01_folded_olive_F"};
+	case "guerrilla": {"Land_TentSolar_01_folded_olive_F"};
+	case "civilian":  {"Land_TentSolar_01_folded_sand_F"};
+	default           {"RoadCone_L_F"};
 };
 
-_lockerBag = _bagType createVehicleLocal [0,0,0];
-
+private _lockerBag = _bagType createVehicleLocal [0,0,0];
 private _lockerHeightTop = (0 boundingBoxReal _locker) # 1 # 2;
 private _bagHeightBottom = (0 boundingBoxReal _lockerBag) # 0 # 2;
 
 _lockerBag attachTo [_locker, [0,0,_lockerHeightTop - _bagHeightBottom]];
+_locker setVariable ["f_var_lockerBag", _lockerBag, false];
+
+_locker addEventHandler ["Deleted",
+	{
+		params ["_locker"];
+
+		deleteVehicle (_locker getVariable ["f_var_lockerBag", objNull]);
+	}
+];

--- a/components/gearScript/zen/fn_zen_createLoadoutLocker.sqf
+++ b/components/gearScript/zen/fn_zen_createLoadoutLocker.sqf
@@ -21,6 +21,12 @@ private _createLocker =
         private _lockerModel = ["Metal_Locker_F", "Land_OfficeCabinet_02_F"] select (isNull (configFile >> "CfgVehicles" >> "Metal_Locker_F"));
         _locker = _lockerModel createVehicle [0,0,0];
         _locker setPosASL _position;
+
+        {
+            if (!isNull getAssignedCuratorUnit _x) then {
+                [_x, [[_locker], false]] remoteExecCall ["addCuratorEditableObjects", 2, false];
+            };
+        } forEach allCurators;
     };
 
     // In case picked object becomes a locker while zeus is in the side selection menu.

--- a/description.ext
+++ b/description.ext
@@ -38,7 +38,7 @@ loadScreen = "ca_logo_large.jpg";
 
 
 enableDebugConsole = 1;
-allowFunctionsRecompile = 1; // Enables using BIS_fnc_recompile from 3DEN preview
+allowFunctionsRecompile = __EVAL(is3DENPreview); // Enables using BIS_fnc_recompile from 3DEN preview
 
 // CAFE - Debug variable, needs to exist pre-init.
 #include "startup\configuration\internals\debug.sqf"

--- a/description.ext
+++ b/description.ext
@@ -38,6 +38,7 @@ loadScreen = "ca_logo_large.jpg";
 
 
 enableDebugConsole = 1;
+allowFunctionsRecompile = 1; // Enables using BIS_fnc_recompile from 3DEN preview
 
 // CAFE - Debug variable, needs to exist pre-init.
 #include "startup\configuration\internals\debug.sqf"


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add ACE actions to the loadout locker
- Automatically register loadout lockers as Zeus editable objects when spawned (QoL)
- Fix loadout locker bags not being deleted alongside their locker

### Release Notes
Loadout lockers now have ACE actions to take loadouts, alongside the regular vanilla actions.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

Closes #170.