### PR TITLE
[Improve] - Zeus UI initialisation & Godmode

### DIFF
--- a/components/miscShared/fn_giveUnitGodmode.sqf
+++ b/components/miscShared/fn_giveUnitGodmode.sqf
@@ -17,14 +17,20 @@
 
 */
 
-params ["_unit", ["_keepHealthy", false]];
+params [
+	["_unit", objNull, [objNull]],
+	["_keepHealthy", false, [false]]
+];
 
 LOCAL_ONLY(_unit);
 
-[_unit, false] remoteExec ["allowDamage", 0, true];
+[_unit, false] remoteExecCall ["allowDamage", 0, true];
 _unit setVariable ["ace_medical_allowDamage", false, true];
 
-if (_keepHealthy) then
-{
-	[_unit] spawn f_fnc_keepUnitHealthy;
+// Prevent running multiple instances of the "keep-healthy" loop
+if (isNil "handle_fnc_keepUnitHealthy") then {handle_fnc_keepUnitHealthy = scriptNull};
+terminate handle_fnc_keepUnitHealthy;
+
+if (_keepHealthy) then {
+	handle_fnc_keepUnitHealthy = [_unit] spawn f_fnc_keepUnitHealthy;
 };

--- a/components/zeus_ui/fn_addZeusActions.sqf
+++ b/components/zeus_ui/fn_addZeusActions.sqf
@@ -18,7 +18,7 @@ if !(player getVariable ["f_var_isZeus",false]) exitWith {}; // Fallback in case
 
 //ACRE actions
 
-if (["acre_sys_radio"] call ace_common_fnc_isModLoaded) then 
+if (["acre_sys_radio"] call ace_common_fnc_isModLoaded) then
 {
 	private _talkThroughZeus =
 	{
@@ -131,7 +131,7 @@ private _noTurnZeusInvisible =
 {
 	_player setVariable ["f_var_turnZeusInvisible", false, true];
 
-	if (!cafe_ceasefire_active) then {	// Disables AI seeing the Zeus player as hostile when talking in direct speech while hidden
+	if (!cafe_ceasefire_active) then {
 		_player setCaptive false;
 	};
 	[_player, true] remoteExecCall ["f_fnc_activatePlayer", 2];

--- a/components/zeus_ui/fn_openZeus.sqf
+++ b/components/zeus_ui/fn_openZeus.sqf
@@ -13,12 +13,26 @@
 
 CLIENT_ONLY;
 
-if !(player getVariable ["f_var_isZeus",false]) exitWith {}; //Fallback in case the script execution is run on the wrong machine
+// Initialisation
+if (!cafe_zeusUI_isInitialised) then {
+	cafe_zeusUI_isInitialised = true;
+
+	player setVariable ["f_var_isZeus", true, true];
+	player setVariable ["f_var_isKillLogRecipient", true, true];
+
+	player addCuratorEditableObjects [(vehicles + allUnits + allDeadMen), true];
+	player removeCuratorEditableObjects [player, true];
+
+	[] call f_fnc_addZeusActions;
+};
+
+// Godmode
+[player, true] call f_fnc_giveUnitGodmode;
 
 if (player getVariable ["f_var_turnZeusInvisible", true]) then
 {
 	player setCaptive true; //Disables AI seeing the Zeus player as hostile when talking in direct speech while hidden
-	[player, false] remoteExecCall ["f_fnc_activatePlayer", 2]; 
+	[player, false] remoteExecCall ["f_fnc_activatePlayer", 2];
 };
 
 [] spawn //you need to wait for Zeus to actually be open to create the dialog
@@ -32,8 +46,8 @@ if (player getVariable ["f_var_turnZeusInvisible", true]) then
 
 	// Start the custom Zeus UI
 	["ui_init"] call f_fnc_zeusUI;
-	
-    if (["acre_sys_radio"] call ace_common_fnc_isModLoaded) then 
+
+    if (["acre_sys_radio"] call ace_common_fnc_isModLoaded) then
 	{
 		[] call acre_sys_zeus_fnc_handleZeusSpeakPress;  //Fallback in case the variable goes missing.
 	};

--- a/components/zeus_ui/init_component.sqf
+++ b/components/zeus_ui/init_component.sqf
@@ -4,19 +4,4 @@ CLIENT_ONLY;
 
 DEBUG_PRINT_LOG("[Zeus] Initting Zeus components")
 
-
-waitUntil
-{
-    sleep 1;
-    !isNull (findDisplay 312)
-};
-
-player setVariable ["f_var_isKillLogRecipient", true, true];
-player setVariable ["f_var_isZeus", true, true];
-
-[player, true] call f_fnc_giveUnitGodmode;
-
-player addCuratorEditableObjects [(vehicles + allUnits), true];
-player removeCuratorEditableObjects [player, true];
-
-[] call f_fnc_addZeusActions;
+cafe_zeusUI_isInitialised = false;

--- a/description.ext
+++ b/description.ext
@@ -38,7 +38,7 @@ loadScreen = "ca_logo_large.jpg";
 
 
 enableDebugConsole = 1;
-allowFunctionsRecompile = __EVAL(is3DENPreview); // Enables using BIS_fnc_recompile from 3DEN preview
+allowFunctionsRecompile = __EVAL(is3DENPreview or is3DENMultiplayer); // Enables using BIS_fnc_recompile from 3DEN preview
 
 // CAFE - Debug variable, needs to exist pre-init.
 #include "startup\configuration\internals\debug.sqf"


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- fix the custom Zeus UI not opening on the first use of the curator screen
- fix godmode only being applied once on initialisation (rather than everytime the curator display is opened)
- clean up various code areas (remove redundant Zeus UI component initialisation, add a safeguard for script spawning, remove obsolete comments)

NOTE: As per the checkboxes below, please also review [the edited wiki page concerning Zeus](https://github.com/CombinedArmsGaming/CAFE3/wiki/Zeus-and-you,-a-short-guide/_compare/d243490adacb5f4f519383f894521c798e28210f...e678fae124eff09c47635b6917d322e80a2bde18).

### Release Notes
- The Zeus UI now properly shows everytime the Curator screen is opened (previously it didn't show on the first use)
- Zeus God-mode now gets [re]applied everytime the Curator screen is opened (previously only on the first use)

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

