### PR TITLE
[Fix] Resolve Logistics Vehicle Group-Based Access

### DIFF
--- a/components/logiVehicle/fn_canPlayerUseLogi.sqf
+++ b/components/logiVehicle/fn_canPlayerUseLogi.sqf
@@ -29,7 +29,8 @@ if (_roles isNotEqualTo []) then
 	_failedCheck = !(_playerRole in _roles);
 };
 
-if (_failedCheck) exitWith {false};
+// Break out check passed
+if (!_failedCheck) exitWith {true};
 
 private _groups = GET_GROUPS_DYNAMIC(_logiType);
 

--- a/components/logiVehicle/fn_canPlayerUseLogi.sqf
+++ b/components/logiVehicle/fn_canPlayerUseLogi.sqf
@@ -29,7 +29,6 @@ if (_roles isNotEqualTo []) then
 	_failedCheck = !(_playerRole in _roles);
 };
 
-if (_failedCheck) exitWith {false};
 
 private _groups = GET_GROUPS_DYNAMIC(_logiType);
 

--- a/components/logiVehicle/fn_canPlayerUseLogi.sqf
+++ b/components/logiVehicle/fn_canPlayerUseLogi.sqf
@@ -20,24 +20,24 @@ private _logiType = GET_LOGITYPE(_logiVic);
 
 if (_logiType isEqualTo "") exitWith {false};
 
-private _failedCheck = false;
+private _passedCheck = true;
 private _roles = GET_ROLES_DYNAMIC(_logiType);
 
 if (_roles isNotEqualTo []) then
 {
 	private _playerRole = toLower (_player getVariable ["f_var_assignGear", ""]);
-	_failedCheck = !(_playerRole in _roles);
+	_passedCheck = (_playerRole in _roles);
 };
 
 // Break out if check passed
-if (!_failedCheck) exitWith {true};
+if (_passedCheck) exitWith {true};
 
 private _groups = GET_GROUPS_DYNAMIC(_logiType);
 
 if (_groups isNotEqualTo []) then
 {
 	private _playerGroup = toLower (groupId group _player);
-	_failedCheck = !(_playerGroup in _groups);
+	_passedCheck = (_playerGroup in _groups);
 };
 
-(!_failedCheck)
+(_passedCheck)

--- a/components/logiVehicle/fn_canPlayerUseLogi.sqf
+++ b/components/logiVehicle/fn_canPlayerUseLogi.sqf
@@ -20,24 +20,25 @@ private _logiType = GET_LOGITYPE(_logiVic);
 
 if (_logiType isEqualTo "") exitWith {false};
 
-private _failedCheck = false;
+// Default to true for a more pleasurable code reading experience
+private _passedCheck = true;
 private _roles = GET_ROLES_DYNAMIC(_logiType);
 
 if (_roles isNotEqualTo []) then
 {
 	private _playerRole = toLower (_player getVariable ["f_var_assignGear", ""]);
-	_failedCheck = !(_playerRole in _roles);
+	_passedCheck = (_playerRole in _roles);
 };
 
 // Break out if check passed
-if (!_failedCheck) exitWith {true};
+if (_passedCheck) exitWith {true};
 
 private _groups = GET_GROUPS_DYNAMIC(_logiType);
 
 if (_groups isNotEqualTo []) then
 {
 	private _playerGroup = toLower (groupId group _player);
-	_failedCheck = !(_playerGroup in _groups);
+	_passedCheck = (_playerGroup in _groups);
 };
 
-(!_failedCheck)
+(_passedCheck)


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Resolve #181
- No longer ignore group-based access checks for logistics vehicles.

### Release Notes
- Group-based Logistics Vehicle access will now work properly. Any player in a Group with access will now receive it, regardless of their role. In the default framework config, this is any member of COMMAND or ZEUS.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

