### PR TITLE
[Bugfix] - Force players to a specified respawn point if they don't choose one manually.

### DIFF
--- a/components/respawn/cfgRespawnTemplates.hpp
+++ b/components/respawn/cfgRespawnTemplates.hpp
@@ -15,4 +15,6 @@ class CfgRespawnTemplates
 	#include "wave\respawnTemplates.hpp"
 
 	#include "weaponSafety\respawnTemplates.hpp"
+
+	#include "moveToSpawn\respawnTemplates.hpp"
 }

--- a/components/respawn/moveToSpawn/macros.hpp
+++ b/components/respawn/moveToSpawn/macros.hpp
@@ -1,0 +1,2 @@
+#include "../macros.hpp"
+#include "../../../squadmarker_macros.hpp"

--- a/components/respawn/moveToSpawn/onPlayerRespawn.sqf
+++ b/components/respawn/moveToSpawn/onPlayerRespawn.sqf
@@ -1,0 +1,47 @@
+#include "macros.hpp"
+
+/*
+	CAFE Move to Spawn on-respawn script.
+
+	Make sure the player gets teleported when they spawn so they don't just appear on their old corpse.
+    Need to teleport after player respawns - the BIS method doesn't defer execution so we have to do that.
+*/
+
+params ["_newUnit", "_oldUnit", "_respawn", "_respawnDelay"];
+
+// Players shouldn't be moved upon first spawn.
+private _didFirstSpawn = missionNamespace getVariable ["f_var_squad_didFirstSpawn", false];
+missionNamespace setVariable ["f_var_squad_didFirstSpawn", true];
+
+if (_didFirstSpawn) exitWith 
+{
+    private _lastTpTime = missionNamespace getVariable ["f_var_spawnPickerDialog_lastTpTime", 0];
+    if (_lastTpTime > (time - 1)) exitWith {};
+
+    private _spawnArray = missionNamespace getVariable ["f_var_spawnPickerDialog_selectedSpawn", objNull];
+    if (_spawnArray isEqualTo objNull) then 
+    {
+        // Choose an existing respawn point if one was not specified.
+        private _spawns = (_newUnit call bis_fnc_getRespawnPositions) + ((_newUnit call bis_fnc_objectSide) call bis_fnc_getRespawnMarkers);
+
+        if (count _spawns > 0) then
+        {
+            private _spawn = _spawns # 0;
+            _spawnArray = [_spawn, (_spawn call BIS_fnc_showRespawnMenuPositionName) # 0];
+        }
+        else
+        {
+	        ["Unable to find a spawnpoint.  Ping Zeus for assistance."] call f_fnc_createSubtitleText;
+        };        
+    };
+    
+    if (_spawnArray isNotEqualTo objNull) then 
+    {
+        _spawnArray params ["_spawnPoint", ["_spawnName", "Unnamed"]];
+
+        DEBUG_FORMAT3_CHAT("[MoveToSpawn]: Moving player %1 of side %2 to spawnpoint %3",_newUnit,(_newUnit call bis_fnc_objectSide),_spawnName)
+
+        private _success = [_newUnit, _spawnPoint, true] call BIS_fnc_moveToRespawnPosition;
+        missionNamespace setVariable ["f_var_spawnPickerDialog_lastTpTime", time];
+    };
+};

--- a/components/respawn/moveToSpawn/onPlayerRespawn.sqf
+++ b/components/respawn/moveToSpawn/onPlayerRespawn.sqf
@@ -10,8 +10,8 @@
 params ["_newUnit", "_oldUnit", "_respawn", "_respawnDelay"];
 
 // Players shouldn't be moved upon first spawn.
-private _didFirstSpawn = missionNamespace getVariable ["f_var_squad_didFirstSpawn", false];
-missionNamespace setVariable ["f_var_squad_didFirstSpawn", true];
+private _didFirstSpawn = missionNamespace getVariable ["f_var_moveToSpawn_didFirstSpawn", false];
+missionNamespace setVariable ["f_var_moveToSpawn_didFirstSpawn", true];
 
 if (_didFirstSpawn) exitWith 
 {

--- a/components/respawn/moveToSpawn/respawnTemplates.hpp
+++ b/components/respawn/moveToSpawn/respawnTemplates.hpp
@@ -1,0 +1,5 @@
+class CAFE_MoveToSpawn
+{
+	onPlayerRespawn = "components\respawn\moveToSpawn\onPlayerRespawn.sqf";
+	isCall = 1;
+};

--- a/components/respawn/ui_functions/fn_spawnPickerDialog_onCloseDialog.sqf
+++ b/components/respawn/ui_functions/fn_spawnPickerDialog_onCloseDialog.sqf
@@ -34,25 +34,4 @@ if (_exitCode == 1) then
 
     missionNamespace setVariable ["f_var_spawnPickerDialog_selectedSpawn", _spawn];
 
-    // Need to teleport after player respawns - the BIS method doesn't defer execution so we have to do that.
-    [
-        {
-            alive player
-        },
-        {
-            private _lastTpTime = missionNamespace getVariable ["f_var_spawnPickerDialog_lastTpTime", 0];
-            if (_lastTpTime > (time - 1)) exitWith {};
-
-            private _spawn = missionNamespace getVariable ["f_var_spawnPickerDialog_selectedSpawn", objNull];
-            if (_spawn isEqualTo objNull) exitWith 
-            {
-	            ["Unable to spawn at your chosen location.  Teleport to a squad or ping Zeus."] call f_fnc_createSubtitleText;
-            };
-
-            private _success = [player, _spawn # 0, true] call BIS_fnc_moveToRespawnPosition;
-            missionNamespace setVariable ["f_var_spawnPickerDialog_lastTpTime", time];
-        },
-        []
-    
-    ] call CBA_fnc_waitUntilAndExecute;
 };

--- a/respawn_macros.hpp
+++ b/respawn_macros.hpp
@@ -5,14 +5,14 @@
 
 #define RESPAWN_MENU "MenuPosition"
 
-#define RESPAWN_MODE_TIMED                  	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TIMED_TICKETS              {"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TIMED_WAVES            	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED_WAVE, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TICKETS                	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TIMED_WAVES_TICKETS    	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED_WAVE, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TRIGGERED_WAVES    		{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TRIGGERED_WAVE, "CAFE_Loadout", "CAFE_Squad"}
-#define RESPAWN_MODE_TRIGGERED_WAVES_TICKETS    {"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TRIGGERED_WAVE, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad"}
+#define RESPAWN_MODE_TIMED                  	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TIMED_TICKETS              {"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TIMED_WAVES            	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED_WAVE, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TICKETS                	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TIMED_WAVES_TICKETS    	{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TIMED_WAVE, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TRIGGERED_WAVES    		{"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TRIGGERED_WAVE, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
+#define RESPAWN_MODE_TRIGGERED_WAVES_TICKETS    {"CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", RESPAWN_TRIGGERED_WAVE, RESPAWN_TICKETS, "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"}
 
-#define RESPAWN_DEFAULTS "CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", "CAFE_Loadout", "CAFE_Squad"
+#define RESPAWN_DEFAULTS "CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"
 
 #define DEFAULT_RESPAWN_ARRAY {RESPAWN_DEFAULTS}


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Force players to a specified respawn point if they don't choose one manually.

### Release Notes
Players could find themselves respawning in odd positions before - in the middle of nowhere, on top of their old body etc.  Now, if a player doesn't choose their spawnpoint manually with the CTRL+S spectator keybind, a proper one will be chosen for them.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes. **(tested locally in editor MP)**
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

