### PR TITLE
[Feature] - Return of the Respawn Squares

### DIFF
--- a/components/respawn/functions.hpp
+++ b/components/respawn/functions.hpp
@@ -42,6 +42,7 @@ class respawn_zen
     class allowImmediateRespawnLocal{};
     class zen_allowImmediateRespawn{};
     class zen_createRespawnPoint{};
+    class zen_createRespawnSquare{};
     class zen_changeTickets{};
 };
 class respawn_ui

--- a/components/respawn/zen/fn_allowImmediateRespawnLocal.sqf
+++ b/components/respawn/zen/fn_allowImmediateRespawnLocal.sqf
@@ -1,9 +1,17 @@
 #include "../macros.hpp"
 
+params [["_location", objNull], ["_locationName", "Unnamed"]];
+
 private _ticketsRemaining = [player, 0, true] call BIS_fnc_respawnTickets;
 if (_ticketsRemaining <= 0) then
 {
     [player, 1, false] call BIS_fnc_respawnTickets;
+};
+
+if (_location isNotEqualTo objNull) then
+{
+    systemChat format ["Respawning at %1, %2", _location, _locationName];
+    missionNamespace setVariable ["f_var_spawnPickerDialog_selectedSpawn", [_location, _locationName]];
 };
 
 setPlayerRespawnTime MINIMUM_RESPAWN_DELAY;

--- a/components/respawn/zen/fn_allowImmediateRespawnLocal.sqf
+++ b/components/respawn/zen/fn_allowImmediateRespawnLocal.sqf
@@ -1,6 +1,6 @@
 #include "../macros.hpp"
 
-params [["_location", objNull], ["_locationName", "Unnamed"]];
+params [["_location", objNull, [objNull, []]], ["_locationName", "Unnamed", [""]]];
 
 private _ticketsRemaining = [player, 0, true] call BIS_fnc_respawnTickets;
 if (_ticketsRemaining <= 0) then

--- a/components/respawn/zen/fn_zen_createRespawnSquare.sqf
+++ b/components/respawn/zen/fn_zen_createRespawnSquare.sqf
@@ -1,0 +1,55 @@
+#include "../macros.hpp"
+
+params ["_position", "_object"];
+
+private _square = "VR_Area_01_square_1x1_yellow_F" createVehicleLocal (ASLToAGL _position);
+
+f_fnc_respawnRandoAtSquare = 
+{
+    params ["_square"];
+    
+    private _eligiblePlayers = allPlayers 
+        select {!alive _x} 
+        select {(_x getVariable ["f_var_lastSquareRespawnAttempt", 0]) < (CBA_missionTime - 1)};
+
+    private _eligibleCount = count _eligiblePlayers;
+    if (_eligibleCount <= 0) exitWith {false};
+
+    private _player = _eligiblePlayers # (floor random count _eligiblePlayers);
+    _player setVariable ["f_var_lastSquareRespawnAttempt", CBA_missionTime, true];
+    
+    [ASLToAGL getPosASL _square, "Respawn square"] remoteExec ["f_fnc_allowImmediateRespawnLocal", _player];
+    deleteVehicle _square;
+};
+
+f_fnc_onSquareTimeout = 
+{
+    params ["_square"];
+    if (!alive _square) exitWith {};
+
+    _square setObjectTexture [0, "#(argb,8,8,3)color(0.1,0.8,0.3,1,co)"];
+    private _successfulRespawn = [_square] call f_fnc_respawnRandoAtSquare;
+
+    if !(_successfulRespawn) then
+    {
+        [
+            f_fnc_onSquareTimeout, 
+            _this,
+            5
+        ] call CBA_fnc_waitAndExecute;
+    }
+    else
+    {        
+        _square setObjectTexture [0, "#(argb,8,8,3)color(0.5,0.2,0.1,1,co)"];
+    };
+};
+
+[
+    {!alive _this},
+    {},
+    _square,
+    5,
+    f_fnc_onSquareTimeout
+] call CBA_fnc_waitUntilAndExecute;
+
+systemChat "Respawn square will activate in 5s.  Delete the square to cancel.";

--- a/components/respawn/zen/fn_zen_createRespawnSquare.sqf
+++ b/components/respawn/zen/fn_zen_createRespawnSquare.sqf
@@ -27,10 +27,9 @@ f_fnc_respawnRandoAtSquare =
         select {!alive _x} 
         select {(_x getVariable ["f_var_lastSquareRespawnAttempt", 0]) < (CBA_missionTime - (MINIMUM_RESPAWN_DELAY + SQUARE_POLL_RATE + 1))};
 
-    private _eligibleCount = count _eligiblePlayers;
-    if (_eligibleCount <= 0) exitWith {false};
+    if (_eligiblePlayers isEqualTo []) exitWith {false};
 
-    private _player = _eligiblePlayers # (floor random count _eligiblePlayers);
+    private _player = selectRandom _eligiblePlayers;
     _player setVariable ["f_var_lastSquareRespawnAttempt", CBA_missionTime, true];
     
     [ASLToAGL getPosASL _square, "Respawn square"] remoteExec ["f_fnc_allowImmediateRespawnLocal", _player];
@@ -42,11 +41,10 @@ f_fnc_onSquareTimeout =
     params ["_square"];
     if (!alive _square) exitWith {};
 
-    _square setObjectTexture [0, "#(argb,8,8,3)color(0.1,0.8,0.3,1,co)"];
     private _successfulRespawn = [_square] call f_fnc_respawnRandoAtSquare;
-
     if !(_successfulRespawn) then
     {
+         _square setObjectTexture [0, "#(argb,8,8,3)color(0.1,0.8,0.3,1,co)"];
         [
             f_fnc_onSquareTimeout, 
             _this,

--- a/components/respawn/zen/fn_zen_createRespawnSquare.sqf
+++ b/components/respawn/zen/fn_zen_createRespawnSquare.sqf
@@ -1,4 +1,5 @@
 #include "../macros.hpp"
+#define SQUARE_POLL_RATE 5
 
 params ["_position", "_object"];
 
@@ -24,7 +25,7 @@ f_fnc_respawnRandoAtSquare =
     
     private _eligiblePlayers = allPlayers 
         select {!alive _x} 
-        select {(_x getVariable ["f_var_lastSquareRespawnAttempt", 0]) < (CBA_missionTime - 1)};
+        select {(_x getVariable ["f_var_lastSquareRespawnAttempt", 0]) < (CBA_missionTime - (MINIMUM_RESPAWN_DELAY + SQUARE_POLL_RATE + 1))};
 
     private _eligibleCount = count _eligiblePlayers;
     if (_eligibleCount <= 0) exitWith {false};
@@ -49,7 +50,7 @@ f_fnc_onSquareTimeout =
         [
             f_fnc_onSquareTimeout, 
             _this,
-            5
+            SQUARE_POLL_RATE
         ] call CBA_fnc_waitAndExecute;
     }
     else

--- a/components/respawn/zen/fn_zen_createRespawnSquare.sqf
+++ b/components/respawn/zen/fn_zen_createRespawnSquare.sqf
@@ -2,7 +2,21 @@
 
 params ["_position", "_object"];
 
-private _square = "VR_Area_01_square_1x1_yellow_F" createVehicleLocal (ASLToAGL _position);
+private _squarePos = _position;
+
+if !(isNull curatorCamera) then
+{
+    private _camPos = getPosASL curatorCamera;
+    private _results = lineIntersectsSurfaces [_camPos, _position, objNull, objNull, true, 1];
+
+    if (count _results > 0) then
+    {
+        _squarePos = _results # 0 # 0;
+    };
+};
+
+private _square = "VR_Area_01_square_1x1_yellow_F" createVehicleLocal _squarePos;
+_square setPosASL (_squarePos vectorAdd [0,0,0.1]);
 
 f_fnc_respawnRandoAtSquare = 
 {

--- a/components/respawn/zen_modules.sqf
+++ b/components/respawn/zen_modules.sqf
@@ -5,6 +5,9 @@ call
     private _makeRespawn = { _this call f_fnc_zen_createRespawnPoint };
     [_category, "Create Respawn Point", _makeRespawn] call zen_custom_modules_fnc_register;
 
+    private _makeSquare = { _this call f_fnc_zen_createRespawnSquare };
+    [_category, "Respawn Player at Cursor", _makeSquare] call zen_custom_modules_fnc_register;
+
     private _changeTickets = { _this call f_fnc_zen_changeTickets };
     [_category, "Change Respawn Tickets", _changeTickets] call zen_custom_modules_fnc_register;
 

--- a/configuration/respawn.hpp
+++ b/configuration/respawn.hpp
@@ -36,7 +36,7 @@
 #define INITIAL_RESPAWN_DELAY               5
 
 #define RESPAWN_MODE_BLUFOR                 RESPAWN_MODE_TIMED_WAVES_TICKETS
-#define RESPAWN_DELAY_BLUFOR                10
+#define RESPAWN_DELAY_BLUFOR                180
 #define RESPAWN_SIDE_TICKETS_BLUFOR         30
 #define RESPAWN_PLAYER_TICKETS_BLUFOR       2
        


### PR DESCRIPTION
Resolves #195

### Pull Request Description
**When merged this pull request will:**
- Add a "Respawn Player at Cursor" ZEN module.
- Change default minimum respawn delay to 3 mins.

### Release Notes
Added a "Respawn Player at Cursor" ZEN module (the old "respawn squares" are back!)
Changed default minimum respawn delay to 3 mins.  No more 10-second respawns (unless you specifically set it.)

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

