### PR TITLE
[Feature] Allow running of code upon logi-vic spawned vehicles.

### DIFF
--- a/components/logiVehicle/fn_createLogiSpawnAction.sqf
+++ b/components/logiVehicle/fn_createLogiSpawnAction.sqf
@@ -43,7 +43,7 @@ private _modifierCode =
 
 	private _type = _target getVariable [LOGIVIC_VAR_DYNAMIC(_spawnIndex,"type"), ""];
 	private _remaining = _target getVariable [LOGIVIC_VAR_DYNAMIC(_spawnIndex,"amount"), 0];
-	private _gear = _target getVariable [LOGIVIC_VAR_DYNAMIC(_spawnIndex,"gear"), ""];
+	private _gearOrCode = _target getVariable [LOGIVIC_VAR_DYNAMIC(_spawnIndex,"gear"), ""];
 	private _text = _target getVariable [LOGIVIC_VAR_DYNAMIC(_spawnIndex,"text"), ""];
 
 	private _newDisplayText = if (_text isNotEqualTo "") then
@@ -52,13 +52,13 @@ private _modifierCode =
 	}
 	else
 	{
-		if (_gear isEqualTo "") then
+		if ((_gearOrCode isEqualTo "") or (typeName _gearOrCode isEqualTo "CODE")) then
 		{
 			format ["Deploy '%1' (%2 remaining)", GET_VEHICLE_DISPLAY_NAME(_type), _remaining]
 		}
 		else
 		{
-			format ["Deploy '%1' with '%3' gear (%2 remaining)", GET_VEHICLE_DISPLAY_NAME(_type), _remaining, _gear]
+			format ["Deploy '%1' with '%3' gear (%2 remaining)", GET_VEHICLE_DISPLAY_NAME(_type), _remaining, _gearOrCode]
 		}
 	};
 

--- a/components/logiVehicle/fn_createLogiSpawnAction.sqf
+++ b/components/logiVehicle/fn_createLogiSpawnAction.sqf
@@ -52,7 +52,7 @@ private _modifierCode =
 	}
 	else
 	{
-		if ((_gearOrCode isEqualTo "") or (typeName _gearOrCode isEqualTo "CODE")) then
+		if ((_gearOrCode isEqualTo "") or (_gearOrCode isEqualType {})) then
 		{
 			format ["Deploy '%1' (%2 remaining)", GET_VEHICLE_DISPLAY_NAME(_type), _remaining]
 		}

--- a/components/logiVehicle/fn_logiDoSpawnVehicle.sqf
+++ b/components/logiVehicle/fn_logiDoSpawnVehicle.sqf
@@ -33,7 +33,7 @@ private _message = if (_text isNotEqualTo "") then
 }
 else
 {
-	if ((_gearOrCode isEqualTo "") or (typeName _gearOrCode isEqualTo "CODE")) then
+	if ((_gearOrCode isEqualTo "") or (_gearOrCode isEqualType {})) then
 	{
 		format ["Deploying '%1'...", GET_VEHICLE_DISPLAY_NAME(_type)]
 	}
@@ -96,7 +96,7 @@ _sign2 setPos (_logiVic modelToWorld [0,0,1]);
 
 
 // If vehicle has survived, fill it with any specified gear.
-if (typeName _gearOrCode isEqualTo "CODE") then
+if (_gearOrCode isEqualType {}) then
 {
 	private _logiType = GET_LOGITYPE(_logiVic);
 	private _faction = GET_FACTION_DYNAMIC(_logiType);

--- a/components/logiVehicle/fn_logiDoSpawnVehicle.sqf
+++ b/components/logiVehicle/fn_logiDoSpawnVehicle.sqf
@@ -20,7 +20,7 @@
 
 RUN_AS_ASYNC(f_fnc_logiDoSpawnVehicle);
 
-params ["_spawnType", "_logiVic", "_gearscriptType", "_text"];
+params ["_spawnType", "_logiVic", "_gearOrCode", "_text"];
 
 if LOGIVIC_IS_SPAWNING(_logiVic) exitWith {false};
 SET_LOGIVIC_SPAWNING(_logiVic,true);
@@ -33,7 +33,7 @@ private _message = if (_text isNotEqualTo "") then
 }
 else
 {
-	if (_gearscriptType isEqualTo "") then
+	if ((_gearOrCode isEqualTo "") or (typeName _gearOrCode isEqualTo "CODE")) then
 	{
 		format ["Deploying '%1'...", GET_VEHICLE_DISPLAY_NAME(_type)]
 	}
@@ -96,18 +96,27 @@ _sign2 setPos (_logiVic modelToWorld [0,0,1]);
 
 
 // If vehicle has survived, fill it with any specified gear.
-if (_gearscriptType isNotEqualTo "") then
+if (typeName _gearOrCode isEqualTo "CODE") then
 {
 	private _logiType = GET_LOGITYPE(_logiVic);
 	private _faction = GET_FACTION_DYNAMIC(_logiType);
-
-	if (_faction isEqualTo "") then
+	[_spawnedVic, _logiVic, _logiType, _faction, _text] call _gearOrCode;
+}
+else
+{
+	if (_gearOrCode isNotEqualTo "") then
 	{
-		DEBUG_PRINT_CHAT("[LOGI-VICS]: Faction not specified for logi vic '%1', defaulting to 'blu_f'.")
-		_faction = "blu_f";
-	};
+		private _logiType = GET_LOGITYPE(_logiVic);
+		private _faction = GET_FACTION_DYNAMIC(_logiType);
 
-	[_gearscriptType, _spawnedVic, _faction] call f_fnc_assignGear;
+		if (_faction isEqualTo "") then
+		{
+			DEBUG_PRINT_CHAT("[LOGI-VICS]: Faction not specified for logi vic '%1', defaulting to 'blu_f'.")
+			_faction = "blu_f";
+		};
+
+		[_gearOrCode, _spawnedVic, _faction] call f_fnc_assignGear;
+	};
 };
 
 

--- a/configuration/logiVehicle.sqf
+++ b/configuration/logiVehicle.sqf
@@ -37,6 +37,8 @@ SET_CUSTOM_NAME("Large Ammo Crate");
 // Special "Init" code, see below for details.
 private _tankCode = 
 {
+    // This code will execute locally to the person using the action.
+    // This will be executed ~5s after the vehicle has been moved into the AO.
     params ["_spawnedVic", "_logiVic", "_logiType", "_faction", "_spawnedVicName"];
 
     // Enable hunter-killer by default.

--- a/configuration/logiVehicle.sqf
+++ b/configuration/logiVehicle.sqf
@@ -33,6 +33,24 @@ SET_CUSTOM_NAME("Small Ammo Crate"); // This command lets you give a custom name
 ADD_VEHICLE_WITH_GEAR(example,"B_supplyCrate_F",5,"crate_med");
 SET_CUSTOM_NAME("Large Ammo Crate");
 
+
+// Special "Init" code, see below for details.
+private _tankCode = 
+{
+    params ["_spawnedVic", "_logiVic", "_logiType", "_faction", "_spawnedVicName"];
+
+    // Enable hunter-killer by default.
+    _spawnedVic setVariable ["ace_hunterkiller", true, true];
+
+    // Add a toolkit and backpack only.
+    _spawnedVic addItemCargoGlobal ["Toolkit", 1];
+    _spawnedVic addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+};
+
+// This special command lets you run some code on the vehicle you just spawned, kind of like the "Init" box in the editor.
+ADD_VEHICLE_WITH_CODE(example,"B_MBT_01_cannon_F",2,_tankCode);
+
+
 // Set the faction of the logi vehicle.  Used to choose the correct gear for gearscripted crates etc.
 SET_FACTION(example,"blu_f");
 

--- a/logi_macros.hpp
+++ b/logi_macros.hpp
@@ -35,6 +35,10 @@
     _logiVicToAdd = [VICTYPE, AMOUNT, GEAR, ""];                \
     GET_VAR(LOGIVIC_VAR(NAME,Vics),[]) pushBack _logiVicToAdd
 
+#define ADD_VEHICLE_WITH_CODE(NAME,VICTYPE,AMOUNT,CODE)         \
+    _logiVicToAdd = [VICTYPE, AMOUNT, CODE, ""];                \
+    GET_VAR(LOGIVIC_VAR(NAME,Vics),[]) pushBack _logiVicToAdd
+
 #define SET_CUSTOM_NAME(NAME) _logiVicToAdd set [3, NAME]
 
 #define ROLES_VAR(NAME) LOGIVIC_VAR(NAME,Roles)


### PR DESCRIPTION
Resolves #143

### Pull Request Description
**When merged this pull request will:**
- Allow running of code upon logi-vic spawned vehicles via config file.
- Add an example of the new ADD_VEHICLE_WITH_CODE macro to the logivic config file.

### Release Notes
You can now run code upon vehicles that you've spawned with a logi vic.  For more information see the `ADD_VEHICLE_WITH_CODE` example in the `configuration\logiVehicle.sqf` config file.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

