### PR TITLE
[Feature] Added hunter-killer ACE action to crew slots of all land and sea vehicles.

### DIFF
--- a/components/aceActions/fn_addHunterKillerActions.sqf
+++ b/components/aceActions/fn_addHunterKillerActions.sqf
@@ -18,9 +18,9 @@ private _enableCondition =
     private _role = toLower ((assignedVehicleRole player) param [0, "cargo"]);
 
     private _playerCanUse = ((vehicle _player) isEqualTo _vehicle) and {!(_role isEqualTo "cargo")};
-    private _driverNotActive = !(_vehicle getVariable ["ace_hunterkiller", false]);
+    private _hunterKillerNotActive = !(_vehicle getVariable ["ace_hunterkiller", false]);
 
-    _playerCanUse and _driverNotActive;
+    _playerCanUse and _hunterKillerNotActive;
 
 };
 
@@ -31,9 +31,9 @@ private _disableCondition =
     private _role = toLower ((assignedVehicleRole player) param [0, "cargo"]);
 
     private _playerCanUse = ((vehicle _player) isEqualTo _vehicle) and {!(_role isEqualTo "cargo")};
-    private _driverActive = (_vehicle getVariable ["ace_hunterkiller", false]);
+    private _hunterKillerActive = (_vehicle getVariable ["ace_hunterkiller", false]);
 
-    _playerCanUse and _driverActive;
+    _playerCanUse and _hunterKillerActive;
 
 };
 

--- a/components/aceActions/fn_addHunterKillerActions.sqf
+++ b/components/aceActions/fn_addHunterKillerActions.sqf
@@ -1,0 +1,95 @@
+#include "macros.hpp"
+
+params ["_unit"];
+
+private _type = typeOf _unit;
+
+if (isNil "f_arr_hunterKillerActionClasses") then {f_arr_hunterKillerActionClasses = [];};
+if (_type in f_arr_hunterKillerActionClasses) exitWith {};
+
+f_arr_hunterKillerActionClasses pushBack _type;
+
+
+
+
+private _enableCondition =
+{
+    params ["_vehicle", "_player"];
+    private _role = toLower ((assignedVehicleRole player) param [0, "cargo"]);
+
+    private _playerCanUse = ((vehicle _player) isEqualTo _vehicle) and {!(_role isEqualTo "cargo")};
+    private _driverNotActive = !(_vehicle getVariable ["ace_hunterkiller", false]);
+
+    _playerCanUse and _driverNotActive;
+
+};
+
+
+private _disableCondition =
+{
+    params ["_vehicle", "_player"];
+    private _role = toLower ((assignedVehicleRole player) param [0, "cargo"]);
+
+    private _playerCanUse = ((vehicle _player) isEqualTo _vehicle) and {!(_role isEqualTo "cargo")};
+    private _driverActive = (_vehicle getVariable ["ace_hunterkiller", false]);
+
+    _playerCanUse and _driverActive;
+
+};
+
+
+private _onEnable =
+{
+    params ["_vehicle"];
+    private _vicType = typeOf _vehicle;
+    private _hunterKillerValue = f_dict_hunterKillerOverrides getOrDefault [_vicType, true];
+
+    _vehicle setVariable ["ace_hunterkiller", _hunterKillerValue, true];
+};
+
+
+private _onDisable =
+{
+    params ["_vehicle"];
+    _vehicle setVariable ["ace_hunterkiller", false, true];
+};
+
+
+private _enableAction =
+[
+    "CA_EnableHunterKiller",
+    "Enable ACE Hunter-Killer",
+    "\A3\ui_f\data\igui\cfg\simpleTasks\types\kill_ca.paa",
+    _onEnable,
+    _enableCondition,
+    nil,
+    [],
+    "",
+    20,
+    [false,false,false,false,false],
+    {}
+];
+
+
+private _disableAction =
+[
+    "CA_DisableHunterKiller",
+    "Deactivate ACE Hunter-Killer",
+    "\A3\ui_f\data\igui\cfg\simpleTasks\types\kill_ca.paa",
+    _onDisable,
+    _disableCondition,
+    nil,
+    [],
+    "",
+    20,
+    [false,false,false,false,false],
+    {}
+];
+
+
+_enableAction call ace_interact_menu_fnc_createAction;
+_disableAction call ace_interact_menu_fnc_createAction;
+
+
+[_type, 1, ["ACE_SelfActions"], _enableAction, true] call ace_interact_menu_fnc_addActionToClass;
+[_type, 1, ["ACE_SelfActions"], _disableAction, true] call ace_interact_menu_fnc_addActionToClass;

--- a/components/aceActions/functions.hpp
+++ b/components/aceActions/functions.hpp
@@ -2,6 +2,7 @@ class aceActions
 {
     file = "components\aceActions";
     class addHeliMusic{};
+    class addHunterKillerActions{};
     class addInventoryActionToClass{};
     class addSquadManagerActionsToClass{};
     class addPushActionToClass{};

--- a/components/aceActions/globals.sqf
+++ b/components/aceActions/globals.sqf
@@ -1,0 +1,11 @@
+#include "macros.hpp"
+
+// Use this array to define hunter-killer overrides for specific vehicles.
+// For more information about "custom arrays", see the following documentation:
+// https://ace3.acemod.org/wiki/framework/hunterkiller-framework
+// https://community.bistudio.com/wiki/unitTurret
+
+f_dict_hunterKillerOverrides = createHashMapFromArray
+[
+	["My_Example_Vehicle", [[0], [0, 0]]]
+];

--- a/configuration/aceActions.hpp
+++ b/configuration/aceActions.hpp
@@ -10,3 +10,8 @@
 // Enables push ACE action for boats.
 // To disable the unflip action, comment-out or delete the line below.
 #define ENABLE_PUSH_BOATS_ACTION
+
+// Enables hunter-killer ACE action for vehicles.
+// To customise hunter-killer, see 'components\aceActions\globals.sqf'.
+// To disable the hunter-killer action, comment-out or delete the line below.
+#define ENABLE_HUNTER_KILLER_ACTION

--- a/description.ext
+++ b/description.ext
@@ -410,6 +410,15 @@ class Extended_InitPost_EventHandlers
 
 #endif
 
+#ifdef ENABLE_HUNTER_KILLER_ACTION
+
+		class addHunterKillerAction
+		{
+			init = "_this call f_fnc_addHunterKillerActions";
+		};
+
+#endif
+
 		class addAiDriverAction
 		{
 			init = "_this call f_fnc_addAiDriverActions";
@@ -419,18 +428,28 @@ class Extended_InitPost_EventHandlers
 
 
 
-#ifdef ENABLE_PUSH_BOATS_ACTION
-
 	class Ship
 	{
+		
+#ifdef ENABLE_PUSH_BOATS_ACTION
+
 		class addPushAction
 		{
 			init = "_this call f_fnc_addPushActionToClass";
 		};
-	};
 
 #endif
 
+#ifdef ENABLE_HUNTER_KILLER_ACTION
+
+		class addHunterKillerAction
+		{
+			init = "_this call f_fnc_addHunterKillerActions";
+		};
+
+#endif
+
+	};
 
 
 

--- a/startup/components/globals/clientGlobals.sqf
+++ b/startup/components/globals/clientGlobals.sqf
@@ -1,5 +1,5 @@
-// Client startup group
-// Executes all scripts needed by a normal client.
+// Client globals group
+// Executes all scripts needed before init.
 
 #include "macros.hpp"
 
@@ -12,3 +12,5 @@ LOAD_GLOBALS(respawn)
 LOAD_GLOBALS(gearScript)
 
 LOAD_GLOBALS(radio)
+
+LOAD_GLOBALS(aceActions)

--- a/startup/components/globals/serverGlobals.sqf
+++ b/startup/components/globals/serverGlobals.sqf
@@ -1,5 +1,5 @@
-// Client startup group
-// Executes all scripts needed by a normal client.
+// Server globals group
+// Executes all scripts needed before init.
 
 #include "macros.hpp"
 
@@ -10,3 +10,5 @@ LOAD_GLOBALS(respawn)
 LOAD_GLOBALS(gearScript)
 
 LOAD_GLOBALS(radio)
+
+LOAD_GLOBALS(aceActions)


### PR DESCRIPTION
Resolves #142.

### Pull Request Description
**When merged this pull request will:**
- Add hunter-killer ACE action to crew slots of all land and sea vehicles.

### Release Notes
Added hunter-killer ACE action to crew slots.  You can now turn on ACE Hunter-Killer mode when you're crewing a vehicle and use it to point out targets for your gunner.  This action is available in all vehicles that AI Driver is available for.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

