### PR TITLE
[Minor fix] Stop _identity var getting improperly normalised in fn_factionToSideName.sqf

### DIFF
--- a/components/miscShared/fn_factionToSideName.sqf
+++ b/components/miscShared/fn_factionToSideName.sqf
@@ -1,10 +1,9 @@
 
 params ["_faction"];
 
-_faction = toLower _faction;	// "in" compares case-sensitive, meaning {"BLU_F" in ["blu_f"]} returns false.
-				// We don't want this check to fail though, so let's ignore the casing instead.
-_identity = _faction;
+private _identity = _faction;
 
+_faction = toLower _faction;	// "in" compares case-sensitive, meaning {"BLU_F" in ["blu_f"]} returns false.
 
 if (_faction in ["blu_f", "blu_t_f", "blu_ctrg_f", "blu_gen_f", "b_macv"]) then
 {


### PR DESCRIPTION
`_identity` in this function was getting case-normalised, which leads to a technically-incorrect comparison in `components\gearScript\fn_assignGear.sqf` L79.

### Pull Request Description
**When merged this pull request will:**
- Fixes a minor bug in fn_factionToSideName.

### Release Notes
Minor bugfix to gearscript.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

