### PR TITLE
[Feature] - Add Stat-Tracker to Debrief Screen

### DIFF
--- a/components/functions.hpp
+++ b/components/functions.hpp
@@ -25,6 +25,7 @@ class F
 #include "slottingGenerator\functions.hpp"
 #include "spawnNpcs\functions.hpp"
 #include "squadMarkers\functions.hpp"
+#include "statsTracking\functions.hpp"
 #include "viewDistanceEditor\functions.hpp"
 #include "zeus_ui\functions.hpp"
 

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -9,10 +9,10 @@ if (hasInterface) then {
 	["ace_firedPlayer", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
 		if (_unit == player) then {
-			_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
-			_magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
-			_currentCount = _currentShots getOrDefault [_magName, 0];
-			_updated = _currentCount + 1;
+			private _currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
+			private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
+			private _currentCount = _currentShots getOrDefault [_magName, 0];
+			private _updated = _currentCount + 1;
 			_currentShots set [_magName, _updated];
 			missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
 		};
@@ -22,8 +22,8 @@ if (hasInterface) then {
 		params ["_unit", "_state"];
 
 		if (_unit == player && _state == true) then {
-			_currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
-			_updated = _currentUncons + 1;
+			private _currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
+			private _updated = _currentUncons + 1;
 			missionNamespace setVariable ["cafe_playerUncons", _updated, false];
 		};
 	}] call CBA_fnc_addEventHandler;
@@ -31,13 +31,13 @@ if (hasInterface) then {
 	addMissionEventHandler ["Ended",
 	{
 		systemChat "Ending";
-		_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
-		_uncons = missionNamespace getVariable ["cafe_playerUncons", 0];
-		_tableRows = [["Magazine", "| Rounds expended <br/>"]];
-		_text = "";
+		private _currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
+		private _uncons = missionNamespace getVariable ["cafe_playerUncons", 0];
+		private _tableRows = [["Magazine", "| Rounds expended <br/>"]];
+		private _text = "";
 		{
-			_magName = _x;
-			_shots = format ["| %1 <br/>", _y];
+			private _magName = _x;
+			private _shots = format ["| %1 <br/>", _y];
 			_tableRows pushBack [_magName, _shots];
 		} forEach _currentShots;
 		_text = _text + (_tableRows call BIS_fnc_alignTabs);

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -1,8 +1,9 @@
 // Adds event handlers to the given unit, to track various stats for viewing on the debriefing.
 // These event handlers are local to the client, and the data they collect is relevant only 
 // to the client, so we don't need to sync the data across the network.
+params ["_unit"];
 
-// TODO Ensure these do run locally and not globally
+if !(_unit isEqualTo player) exitWith {};
 
 if (hasInterface) then {
 	["ace_firedPlayer", {

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -38,47 +38,6 @@ if (hasInterface) then {
 			_text = _text + format ["%1 | Fired: %2<br/>", _ammo, _shots];
 		} forEach _currentShots;
 		_text = _text + format ["You went unconscious %1 times<br/>", _uncons];_playersKills = createHashMap;
-
-		// _playersKills = createHashMap;
-		// _killLogs = profileNamespace getVariable [FULL_KILL_LOG_KEY_CLIENT, []];
-		// if (isNil 'f_var_currentKillLogIndex') then
-		// {
-		// 	f_var_currentKillLogIndex = count _killLogs;
-		// };
-		// _killTracking = _killLogs select f_var_currentKillLogIndex;
-
-		// {
-
-		// 	_entry = _x;
-		// 	_entryType = _entry select 0;
-
-		// 	if (_entryType isEqualTo "Killed") then
-		// 	{
-		// 		_killer = _entry select 3;
-		// 		_killerName = _killer select 2;
-		// 		_killerSide = _killer select 1;
-		// 		_killerType = _killer select 0;
-
-		// 		_playerLoadouts = ["CO", "SL", "med", "ftl", "eng", "gren", "mk", "mmg", "ammg", "rif", "ar"];	// TODO get the actual list of defined loadouts
-		// 		_isPlayerLoadout = (_playerLoadouts findIf { tolower _x == _killerType } > -1);
-		// 		_isBlufor = (_killerSide == west);
-				
-		// 		if (_isPlayerLoadout == true) then {
-		// 			if (_isBlufor == true) then {
-		// 				_currentKills = _playersKills getOrDefault [_killerName, 0];
-		// 				_currentKills = _currentKills + 1;
-		// 				_playersKills set [_killerName, _currentKills];
-		// 			};
-		// 		};
-		// 	};
-
-		// } forEach _killTracking;
-
-		// _killsText = "";
-		// {
-		// 	_killsText = _killsText + format ["%1 got %2 kills<br/>", _x, _y];
-		// } forEach _playersKills;
 		missionNamespace setVariable ["cafe_playerStatsStr", _text, false];
-		// missionNamespace setVariable ["cafe_killsListStr", _killsText, false];
 	}];
 };

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -1,0 +1,84 @@
+// Adds event handlers to the given unit, to track various stats for viewing on the debriefing.
+// These event handlers are local to the client, and the data they collect is relevant only 
+// to the client, so we don't need to sync the data across the network.
+
+// TODO Ensure these do run locally and not globally
+
+if (hasInterface) then {
+	["ace_firedPlayer", {
+		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
+		systemChat "Player fired";
+		_currentShots = missionNamespace getVariable ["playerShots", createHashMap];
+		_currentCount = _currentShots getOrDefault [_ammo, 0];
+		_updated = _currentCount + 1;
+		_currentShots set [_ammo, _updated];
+		missionNamespace setVariable ["playerShots", _currentShots, false];
+	}] call CBA_fnc_addEventHandler;
+
+	["ace_unconscious", {
+		params ["_unit", "_state"];
+
+		if (_unit == player) then {
+			_currentUncons = missionNamespace getVariable ["playerUncons", 0];
+			_updated = _currentUncons + 1;
+			missionNamespace setVariable ["playerUncons", _updated, false];
+		};
+	}] call CBA_fnc_addEventHandler;
+
+	addMissionEventHandler ["Ended",
+	{
+		systemChat "Ending";
+		_currentShots = missionNamespace getVariable ["playerShots", createHashMap];
+		_currentHits = missionNamespace getVariable ["playerHits", createHashMap];
+		_uncons = missionNamespace getVariable ["playerUncons", 0];
+		_text = "";
+		{
+			_ammo = _x;
+			_shots = _y;
+			_text = _text + format ["%1 | Fired: %2<br/>", _ammo, _shots];
+		} forEach _currentShots;
+		_text = _text + format ["You went unconscious %1 times<br/>", _uncons];_playersKills = createHashMap;
+
+		// _playersKills = createHashMap;
+		// _killLogs = profileNamespace getVariable [FULL_KILL_LOG_KEY_CLIENT, []];
+		// if (isNil 'f_var_currentKillLogIndex') then
+		// {
+		// 	f_var_currentKillLogIndex = count _killLogs;
+		// };
+		// _killTracking = _killLogs select f_var_currentKillLogIndex;
+
+		// {
+
+		// 	_entry = _x;
+		// 	_entryType = _entry select 0;
+
+		// 	if (_entryType isEqualTo "Killed") then
+		// 	{
+		// 		_killer = _entry select 3;
+		// 		_killerName = _killer select 2;
+		// 		_killerSide = _killer select 1;
+		// 		_killerType = _killer select 0;
+
+		// 		_playerLoadouts = ["CO", "SL", "med", "ftl", "eng", "gren", "mk", "mmg", "ammg", "rif", "ar"];	// TODO get the actual list of defined loadouts
+		// 		_isPlayerLoadout = (_playerLoadouts findIf { tolower _x == _killerType } > -1);
+		// 		_isBlufor = (_killerSide == west);
+				
+		// 		if (_isPlayerLoadout == true) then {
+		// 			if (_isBlufor == true) then {
+		// 				_currentKills = _playersKills getOrDefault [_killerName, 0];
+		// 				_currentKills = _currentKills + 1;
+		// 				_playersKills set [_killerName, _currentKills];
+		// 			};
+		// 		};
+		// 	};
+
+		// } forEach _killTracking;
+
+		// _killsText = "";
+		// {
+		// 	_killsText = _killsText + format ["%1 got %2 kills<br/>", _x, _y];
+		// } forEach _playersKills;
+		missionNamespace setVariable ["cafe_playerStatsStr", _text, false];
+		// missionNamespace setVariable ["cafe_killsListStr", _killsText, false];
+	}];
+};

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -22,7 +22,6 @@ if (hasInterface) then {
 		if (_unit == player && _state == true) then {
 			_currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
 			_updated = _currentUncons + 1;
-			systemChat format ["Current Uncons: %1, New uncons: %2, state is %3", _currentUncons, _updated, _state];
 			missionNamespace setVariable ["cafe_playerUncons", _updated, false];
 		};
 	}] call CBA_fnc_addEventHandler;

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -7,19 +7,22 @@
 if (hasInterface) then {
 	["ace_firedPlayer", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-		_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
-		_currentCount = _currentShots getOrDefault [_ammo, 0];
-		_updated = _currentCount + 1;
-		_currentShots set [_ammo, _updated];
-		missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
+		if (_unit == player) then {
+			_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
+			_currentCount = _currentShots getOrDefault [_ammo, 0];
+			_updated = _currentCount + 1;
+			_currentShots set [_ammo, _updated];
+			missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
+		};
 	}] call CBA_fnc_addEventHandler;
 
 	["ace_unconscious", {
 		params ["_unit", "_state"];
 
-		if (_unit == player) then {
+		if (_unit == player && _state == true) then {
 			_currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
 			_updated = _currentUncons + 1;
+			systemChat format ["Current Uncons: %1, New uncons: %2, state is %3", _currentUncons, _updated, _state];
 			missionNamespace setVariable ["cafe_playerUncons", _updated, false];
 		};
 	}] call CBA_fnc_addEventHandler;

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -5,43 +5,45 @@ params ["_unit"];
 
 if !(_unit isEqualTo player) exitWith {};
 
-if (hasInterface) then {
-	["ace_firedPlayer", {
+if (hasInterface) then 
+{
+	["ace_firedPlayer", 
+	{
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-		if (_unit == player) then {
-			private _currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
+
+		if (_unit == player) then 
+		{
 			private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
-			private _currentCount = _currentShots getOrDefault [_magName, 0];
+			private _currentCount = cafe_playerShots getOrDefault [_magName, 0];
 			private _updated = _currentCount + 1;
-			_currentShots set [_magName, _updated];
-			missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
+			cafe_playerShots set [_magName, _updated];
 		};
 	}] call CBA_fnc_addEventHandler;
 
-	["ace_unconscious", {
+	["ace_unconscious", 
+	{
 		params ["_unit", "_state"];
 
-		if (_unit == player && _state == true) then {
-			private _currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
-			private _updated = _currentUncons + 1;
-			missionNamespace setVariable ["cafe_playerUncons", _updated, false];
+		if (_unit == player && _state == true) then 
+		{
+			cafe_playerUncons = cafe_playerUncons + 1;
 		};
 	}] call CBA_fnc_addEventHandler;
 
 	addMissionEventHandler ["Ended",
 	{
-		systemChat "Ending";
-		private _currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
-		private _uncons = missionNamespace getVariable ["cafe_playerUncons", 0];
 		private _tableRows = [["Magazine", "| Rounds expended <br/>"]];
 		private _text = "";
+
 		{
 			private _magName = _x;
 			private _shots = format ["| %1 <br/>", _y];
 			_tableRows pushBack [_magName, _shots];
-		} forEach _currentShots;
+		} forEach cafe_playerShots;
+
 		_text = _text + (_tableRows call BIS_fnc_alignTabs);
-		_text = _text + format ["<br/>You went unconscious %1 time(s)<br/>", _uncons];
+		_text = _text + format ["<br/>You went unconscious %1 time(s)<br/>", cafe_playerUncons];
+
 		missionNamespace setVariable ["cafe_playerStatsStr", _text, false];
 	}];
 };

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -10,9 +10,10 @@ if (hasInterface) then {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
 		if (_unit == player) then {
 			_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
-			_currentCount = _currentShots getOrDefault [_ammo, 0];
+			_magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
+			_currentCount = _currentShots getOrDefault [_magName, 0];
 			_updated = _currentCount + 1;
-			_currentShots set [_ammo, _updated];
+			_currentShots set [_magName, _updated];
 			missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
 		};
 	}] call CBA_fnc_addEventHandler;
@@ -32,13 +33,15 @@ if (hasInterface) then {
 		systemChat "Ending";
 		_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
 		_uncons = missionNamespace getVariable ["cafe_playerUncons", 0];
+		_tableRows = [["Magazine", "| Rounds expended <br/>"]];
 		_text = "";
 		{
-			_ammo = _x;
-			_shots = _y;
-			_text = _text + format ["%1 | Fired: %2<br/>", _ammo, _shots];
+			_magName = _x;
+			_shots = format ["| %1 <br/>", _y];
+			_tableRows pushBack [_magName, _shots];
 		} forEach _currentShots;
-		_text = _text + format ["You went unconscious %1 times<br/>", _uncons];
+		_text = _text + (_tableRows call BIS_fnc_alignTabs);
+		_text = _text + format ["<br/>You went unconscious %1 time(s)<br/>", _uncons];
 		missionNamespace setVariable ["cafe_playerStatsStr", _text, false];
 	}];
 };

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -7,37 +7,35 @@
 if (hasInterface) then {
 	["ace_firedPlayer", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-		systemChat "Player fired";
-		_currentShots = missionNamespace getVariable ["playerShots", createHashMap];
+		_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
 		_currentCount = _currentShots getOrDefault [_ammo, 0];
 		_updated = _currentCount + 1;
 		_currentShots set [_ammo, _updated];
-		missionNamespace setVariable ["playerShots", _currentShots, false];
+		missionNamespace setVariable ["cafe_playerShots", _currentShots, false];
 	}] call CBA_fnc_addEventHandler;
 
 	["ace_unconscious", {
 		params ["_unit", "_state"];
 
 		if (_unit == player) then {
-			_currentUncons = missionNamespace getVariable ["playerUncons", 0];
+			_currentUncons = missionNamespace getVariable ["cafe_playerUncons", 0];
 			_updated = _currentUncons + 1;
-			missionNamespace setVariable ["playerUncons", _updated, false];
+			missionNamespace setVariable ["cafe_playerUncons", _updated, false];
 		};
 	}] call CBA_fnc_addEventHandler;
 
 	addMissionEventHandler ["Ended",
 	{
 		systemChat "Ending";
-		_currentShots = missionNamespace getVariable ["playerShots", createHashMap];
-		_currentHits = missionNamespace getVariable ["playerHits", createHashMap];
-		_uncons = missionNamespace getVariable ["playerUncons", 0];
+		_currentShots = missionNamespace getVariable ["cafe_playerShots", createHashMap];
+		_uncons = missionNamespace getVariable ["cafe_playerUncons", 0];
 		_text = "";
 		{
 			_ammo = _x;
 			_shots = _y;
 			_text = _text + format ["%1 | Fired: %2<br/>", _ammo, _shots];
 		} forEach _currentShots;
-		_text = _text + format ["You went unconscious %1 times<br/>", _uncons];_playersKills = createHashMap;
+		_text = _text + format ["You went unconscious %1 times<br/>", _uncons];
 		missionNamespace setVariable ["cafe_playerStatsStr", _text, false];
 	}];
 };

--- a/components/statsTracking/functions.hpp
+++ b/components/statsTracking/functions.hpp
@@ -1,0 +1,5 @@
+class statsTracking
+{
+    file = "components\statsTracking";
+    class addStatsEventHandlersToClass {};
+};

--- a/components/statsTracking/globals.sqf
+++ b/components/statsTracking/globals.sqf
@@ -1,0 +1,2 @@
+cafe_playerShots = createHashMap;
+cafe_playerUncons = 0;

--- a/configuration/statsTracking.hpp
+++ b/configuration/statsTracking.hpp
@@ -1,0 +1,4 @@
+
+// Enables stat-tracking.
+// To disable stat-tracking, comment-out or delete the line below.
+#define ENABLE_EXTENDED_STATS 1

--- a/description.ext
+++ b/description.ext
@@ -400,7 +400,7 @@ class Extended_InitPost_EventHandlers
 #ifdef ENABLE_EXTENDED_STATS
 		class addStatsEventHandlers
 		{
-			init = "[] call f_fnc_addStatsEventHandlersToClass";
+			init = "_this call f_fnc_addStatsEventHandlersToClass";
 		};
 #endif
 

--- a/description.ext
+++ b/description.ext
@@ -218,6 +218,13 @@ class CfgDebriefingSections
 			variable = "acex_killTracker_outputText";
 	};
 
+#ifdef ENABLE_EXTENDED_STATS
+	class cafe_statsTracker
+	{
+		title = "Personal Stats";
+		variable = "cafe_playerStatsStr";
+	};
+#endif
 };
 
 
@@ -388,6 +395,13 @@ class Extended_InitPost_EventHandlers
 			init = "_this call f_fnc_addViewDistanceActionToClass";
 		};
 
+#endif
+
+#ifdef ENABLE_EXTENDED_STATS
+		class addStatsEventHandlers
+		{
+			init = "[] call f_fnc_addStatsEventHandlersToClass";
+		};
 #endif
 
 		class addSquadManagerActions

--- a/startup/components/globals/clientGlobals.sqf
+++ b/startup/components/globals/clientGlobals.sqf
@@ -16,3 +16,5 @@ LOAD_GLOBALS(radio)
 LOAD_GLOBALS(aceActions)
 
 LOAD_GLOBALS(slottingGenerator)
+
+LOAD_GLOBALS(statsTracking)

--- a/startup/configuration/internals/configMacros.hpp
+++ b/startup/configuration/internals/configMacros.hpp
@@ -17,3 +17,4 @@
 #include "..\..\..\configuration\sogConfig.hpp"
 #include "..\..\..\configuration\respawn.hpp"
 #include "..\..\..\configuration\slottingGenerator.hpp"
+#include "..\..\..\configuration\statsTracking.hpp"


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add a stats page to the debrief screen, tracking the user's rounds expended and number of unconsciouses

### Release Notes
- New page on debrief screen for tracking player's individual stats.
- New configuration file for the above, `configuration/statsTracking.hpp`. This houses the `#define` controlling whether the above feature is enabled.
- Tracking _enabled_ by default.

## IMPORTANT

- [x] Testing has been completed as necessary, depending on the nature & impact of the changes. Note: I'd like to do a little more testing of the unconscious counter. But I have verified that the feature does not break existing functionality, and that it works barring perhaps some edge cases around re-JIPping.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

