### PR TITLE
[Feature] Add Respawn Details Into Briefing

### DIFF
--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -1,23 +1,23 @@
 // CA - Respawn briefing section
 // ====================================================================================
 
-_briefing = "";
-_side = side player;
+private _briefing = "";
+private _side = side player;
 
-_respawnModeTimedText = str RESPAWN_MODE_TIMED;
-_respawnModeTimedTicketsText = str RESPAWN_MODE_TIMED_TICKETS;
-_respawnModeTimedWavesText = str RESPAWN_MODE_TIMED_WAVES;
-_respawnModeTicketsText = str RESPAWN_MODE_TICKETS;
-_respawnModeTimedWavesTicketsText = str RESPAWN_MODE_TIMED_WAVES_TICKETS;
-_respawnModeTriggeredWavesText = str RESPAWN_MODE_TRIGGERED_WAVES;
-_respawnModeTriggeredWavesTicketsText = str RESPAWN_MODE_TRIGGERED_WAVES_TICKETS;
+private _respawnModeTimedText = str RESPAWN_MODE_TIMED;
+private _respawnModeTimedTicketsText = str RESPAWN_MODE_TIMED_TICKETS;
+private _respawnModeTimedWavesText = str RESPAWN_MODE_TIMED_WAVES;
+private _respawnModeTicketsText = str RESPAWN_MODE_TICKETS;
+private _respawnModeTimedWavesTicketsText = str RESPAWN_MODE_TIMED_WAVES_TICKETS;
+private _respawnModeTriggeredWavesText = str RESPAWN_MODE_TRIGGERED_WAVES;
+private _respawnModeTriggeredWavesTicketsText = str RESPAWN_MODE_TRIGGERED_WAVES_TICKETS;
 
 // Defaults for if macros are not defined
-_delay = "Not set";
-_modeName = "Not set";
-_sideTickets = "Not set";
-_individualTickets = "Not set";
-_mode = null;
+private _delay = "Not set";
+private _modeName = "Not set";
+private _sideTickets = "Not set";
+private _individualTickets = "Not set";
+private _mode = null;
 
 if (_side == west) then {
 #ifdef RESPAWN_DELAY_BLUFOR

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -87,27 +87,27 @@ switch _mode do
 	};
 	case _respawnModeTimedTicketsText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED_TICKETS;
 	};
 	case _respawnModeTimedWavesText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED_WAVES;
 	};
 	case _respawnModeTicketsText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TICKETS;
 	};
 	case _respawnModeTimedWavesTicketsText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS;
 	};
 	case _respawnModeTriggeredWavesText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES;
 	};
 	case _respawnModeTriggeredWavesTicketsText: 
 	{
-		_modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS;
 	};
 	default
 	{

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -109,7 +109,7 @@ switch _mode do
 	{
 		modeName = RESPAWN_MODE_NAME_TIMED;
 	};
-	default:
+	default
 	{
 		_modeName = "Not set";
 	};

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -1,0 +1,29 @@
+// CA - Framework briefing section
+// ====================================================================================
+
+_briefing = "";
+_side = side player;
+_delay = 0;
+_mode = RESPAWN_MODE_TIMED_WAVES_TICKETS;
+_sideTickets = 0;
+_individualTickets = 0;
+
+if (_side == west) then {
+	_delay = RESPAWN_DELAY_BLUFOR;
+	_mode = RESPAWN_MODE_BLUFOR;
+	_sideTickets = RESPAWN_SIDE_TICKETS_BLUFOR;
+	_individualTickets = RESPAWN_PLAYER_TICKETS_BLUFOR;
+};
+
+_briefing = _briefing + format ["
+	Respawn Mode: %1
+	<br/>
+	Respawn Delay: %2
+	<br/>
+	Respawn Tickets (Side): %3
+	<br/>
+	Respawn Tickets (Per-Player): %4
+	<br/>
+", _mode, _delay, _sideTickets, _individualTickets];
+
+player createDiaryRecord ["CAFE", ["Current Respawn Settings", _briefing]];

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -1,18 +1,104 @@
-// CA - Framework briefing section
+// CA - Respawn briefing section
 // ====================================================================================
 
 _briefing = "";
 _side = side player;
-_delay = 0;
-_mode = RESPAWN_MODE_TIMED_WAVES_TICKETS;
-_sideTickets = 0;
-_individualTickets = 0;
+
+_respawnModeTimedText = format ["%1", RESPAWN_MODE_TIMED];
+_respawnModeTimedTicketsText = format ["%1", RESPAWN_MODE_TIMED_TICKETS];
+_respawnModeTimedWavesText = format ["%1", RESPAWN_MODE_TIMED_WAVES];
+_respawnModeTicketsText = format ["%1", RESPAWN_MODE_TICKETS];
+_respawnModeTimedWavesTicketsText = format ["%1", RESPAWN_MODE_TIMED_WAVES_TICKETS];
+_respawnModeTriggeredWavesText = format ["%1", RESPAWN_MODE_TRIGGERED_WAVES];
+_respawnModeTriggeredWavesTicketsText = format ["%1", RESPAWN_MODE_TRIGGERED_WAVES_TICKETS];
+
+// Defaults for if macros are not defined
+_delay = "Not set";
+_modeName = "Not set";
+_sideTickets = "Not set";
+_individualTickets = "Not set";
+_mode = null;
 
 if (_side == west) then {
+#ifdef RESPAWN_DELAY_BLUFOR
 	_delay = RESPAWN_DELAY_BLUFOR;
-	_mode = RESPAWN_MODE_BLUFOR;
+#endif
+#ifdef RESPAWN_MODE_BLUFOR
+	_mode = format ["%1", RESPAWN_MODE_BLUFOR];
+#endif
+#ifdef RESPAWN_SIDE_TICKETS_BLUFOR
 	_sideTickets = RESPAWN_SIDE_TICKETS_BLUFOR;
+#endif
+#ifdef RESPAWN_PLAYER_TICKETS_BLUFOR
 	_individualTickets = RESPAWN_PLAYER_TICKETS_BLUFOR;
+#endif
+};
+
+if (_side == east) then {
+#ifdef RESPAWN_DELAY_OPFOR
+	_delay = RESPAWN_DELAY_OPFOR;
+#endif
+#ifdef RESPAWN_MODE_OPFOR
+	_mode = format ["%1", RESPAWN_MODE_OPFOR];
+#endif
+#ifdef RESPAWN_SIDE_TICKETS_OPFOR
+	_sideTickets = RESPAWN_SIDE_TICKETS_OPFOR;
+#endif
+#ifdef RESPAWN_PLAYER_TICKETS_OPFOR
+	_individualTickets = RESPAWN_PLAYER_TICKETS_OPFOR;
+#endif
+};
+
+if (_side == independent) then {
+#ifdef RESPAWN_DELAY_INDFOR
+	_delay = RESPAWN_DELAY_INDFOR;
+#endif
+#ifdef RESPAWN_MODE_INDFOR
+	_mode = format ["%1", RESPAWN_MODE_INDFOR];
+#endif
+#ifdef RESPAWN_SIDE_TICKETS_INDFOR
+	_sideTickets = RESPAWN_SIDE_TICKETS_INDFOR;
+#endif
+#ifdef RESPAWN_PLAYER_TICKETS_INDFOR
+	_individualTickets = RESPAWN_PLAYER_TICKETS_INDFOR;
+#endif
+};
+
+if (_side == civilian) then {
+#ifdef RESPAWN_DELAY_CIVILIAN
+	_delay = RESPAWN_DELAY_CIVILIAN;
+#endif
+#ifdef RESPAWN_MODE_CIVILIAN
+	_mode = format ["%1", RESPAWN_MODE_CIVILIAN];
+#endif
+#ifdef RESPAWN_SIDE_TICKETS_CIVILIAN
+	_sideTickets = RESPAWN_SIDE_TICKETS_CIVILIAN;
+#endif
+#ifdef RESPAWN_PLAYER_TICKETS_CIVILIAN
+	_individualTickets = RESPAWN_PLAYER_TICKETS_CIVILIAN;
+#endif
+};
+
+if (_mode == _respawnModeTimedText) then {
+	_modeName = RESPAWN_MODE_NAME_TIMED;
+}; 
+if (_mode == _respawnModeTimedTicketsText) then {
+	_modeName = RESPAWN_MODE_NAME_TIMED_TICKETS;
+};
+if (_mode == _respawnModeTimedWavesText) then {
+	_modeName = RESPAWN_MODE_NAME_TIMED_WAVES;
+}; 
+if (_mode == _respawnModeTicketsText) then {
+	_modeName = RESPAWN_MODE_NAME_TICKETS;
+}; 
+if (_mode == _respawnModeTimedWavesTicketsText) then {
+	_modeName = RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS;
+}; 
+if (_mode == _respawnModeTriggeredWavesText) then {
+	_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES;
+};
+if (_mode == _respawnModeTriggeredWavesTicketsText) then {
+	_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS;
 };
 
 _briefing = _briefing + format ["
@@ -24,6 +110,6 @@ _briefing = _briefing + format ["
 	<br/>
 	Respawn Tickets (Per-Player): %4
 	<br/>
-", _mode, _delay, _sideTickets, _individualTickets];
+", _modeName, _delay, _sideTickets, _individualTickets];
 
 player createDiaryRecord ["CAFE", ["Current Respawn Settings", _briefing]];

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -4,13 +4,13 @@
 _briefing = "";
 _side = side player;
 
-_respawnModeTimedText = format ["%1", RESPAWN_MODE_TIMED];
-_respawnModeTimedTicketsText = format ["%1", RESPAWN_MODE_TIMED_TICKETS];
-_respawnModeTimedWavesText = format ["%1", RESPAWN_MODE_TIMED_WAVES];
-_respawnModeTicketsText = format ["%1", RESPAWN_MODE_TICKETS];
-_respawnModeTimedWavesTicketsText = format ["%1", RESPAWN_MODE_TIMED_WAVES_TICKETS];
-_respawnModeTriggeredWavesText = format ["%1", RESPAWN_MODE_TRIGGERED_WAVES];
-_respawnModeTriggeredWavesTicketsText = format ["%1", RESPAWN_MODE_TRIGGERED_WAVES_TICKETS];
+_respawnModeTimedText = str RESPAWN_MODE_TIMED;
+_respawnModeTimedTicketsText = str RESPAWN_MODE_TIMED_TICKETS;
+_respawnModeTimedWavesText = str RESPAWN_MODE_TIMED_WAVES;
+_respawnModeTicketsText = str RESPAWN_MODE_TICKETS;
+_respawnModeTimedWavesTicketsText = str RESPAWN_MODE_TIMED_WAVES_TICKETS;
+_respawnModeTriggeredWavesText = str RESPAWN_MODE_TRIGGERED_WAVES;
+_respawnModeTriggeredWavesTicketsText = str RESPAWN_MODE_TRIGGERED_WAVES_TICKETS;
 
 // Defaults for if macros are not defined
 _delay = "Not set";
@@ -24,7 +24,7 @@ if (_side == west) then {
 	_delay = RESPAWN_DELAY_BLUFOR;
 #endif
 #ifdef RESPAWN_MODE_BLUFOR
-	_mode = format ["%1", RESPAWN_MODE_BLUFOR];
+	_mode = str RESPAWN_MODE_BLUFOR;
 #endif
 #ifdef RESPAWN_SIDE_TICKETS_BLUFOR
 	_sideTickets = RESPAWN_SIDE_TICKETS_BLUFOR;
@@ -39,7 +39,7 @@ if (_side == east) then {
 	_delay = RESPAWN_DELAY_OPFOR;
 #endif
 #ifdef RESPAWN_MODE_OPFOR
-	_mode = format ["%1", RESPAWN_MODE_OPFOR];
+	_mode = str RESPAWN_MODE_OPFOR;
 #endif
 #ifdef RESPAWN_SIDE_TICKETS_OPFOR
 	_sideTickets = RESPAWN_SIDE_TICKETS_OPFOR;
@@ -54,7 +54,7 @@ if (_side == independent) then {
 	_delay = RESPAWN_DELAY_INDFOR;
 #endif
 #ifdef RESPAWN_MODE_INDFOR
-	_mode = format ["%1", RESPAWN_MODE_INDFOR];
+	_mode = str RESPAWN_MODE_INDFOR;
 #endif
 #ifdef RESPAWN_SIDE_TICKETS_INDFOR
 	_sideTickets = RESPAWN_SIDE_TICKETS_INDFOR;
@@ -69,7 +69,7 @@ if (_side == civilian) then {
 	_delay = RESPAWN_DELAY_CIVILIAN;
 #endif
 #ifdef RESPAWN_MODE_CIVILIAN
-	_mode = format ["%1", RESPAWN_MODE_CIVILIAN];
+	_mode = str RESPAWN_MODE_CIVILIAN;
 #endif
 #ifdef RESPAWN_SIDE_TICKETS_CIVILIAN
 	_sideTickets = RESPAWN_SIDE_TICKETS_CIVILIAN;
@@ -83,31 +83,31 @@ switch _mode do
 {
 	case _respawnModeTimedText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTimedTicketsText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTimedWavesText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTicketsText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTimedWavesTicketsText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTriggeredWavesText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	case _respawnModeTriggeredWavesTicketsText: 
 	{
-		modeName = RESPAWN_MODE_NAME_TIMED;
+		_modeName = RESPAWN_MODE_NAME_TIMED;
 	};
 	default
 	{

--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -79,26 +79,40 @@ if (_side == civilian) then {
 #endif
 };
 
-if (_mode == _respawnModeTimedText) then {
-	_modeName = RESPAWN_MODE_NAME_TIMED;
-}; 
-if (_mode == _respawnModeTimedTicketsText) then {
-	_modeName = RESPAWN_MODE_NAME_TIMED_TICKETS;
-};
-if (_mode == _respawnModeTimedWavesText) then {
-	_modeName = RESPAWN_MODE_NAME_TIMED_WAVES;
-}; 
-if (_mode == _respawnModeTicketsText) then {
-	_modeName = RESPAWN_MODE_NAME_TICKETS;
-}; 
-if (_mode == _respawnModeTimedWavesTicketsText) then {
-	_modeName = RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS;
-}; 
-if (_mode == _respawnModeTriggeredWavesText) then {
-	_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES;
-};
-if (_mode == _respawnModeTriggeredWavesTicketsText) then {
-	_modeName = RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS;
+switch _mode do 
+{
+	case _respawnModeTimedText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTimedTicketsText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTimedWavesText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTicketsText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTimedWavesTicketsText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTriggeredWavesText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	case _respawnModeTriggeredWavesTicketsText: 
+	{
+		modeName = RESPAWN_MODE_NAME_TIMED;
+	};
+	default:
+	{
+		_modeName = "Not set";
+	};
 };
 
 _briefing = _briefing + format ["

--- a/components/briefing/fn_briefing.sqf
+++ b/components/briefing/fn_briefing.sqf
@@ -27,6 +27,7 @@ _unitSide = side group player;
 DEBUG_FORMAT1_CHAT("DEBUG (briefing.sqf): Player faction: %1", _unitSide)
 
 #include "briefings\ca_briefing_player.sqf";
+#include "briefings\ca_briefing_respawn.sqf";
 
 // ====================================================================================
 

--- a/components/briefing/macros.hpp
+++ b/components/briefing/macros.hpp
@@ -1,9 +1,2 @@
 #include "../../macros.hpp"
-
-#define RESPAWN_MODE_NAME_TIMED "Timed"
-#define RESPAWN_MODE_NAME_TIMED_TICKETS "Timed, with Tickets"
-#define RESPAWN_MODE_NAME_TIMED_WAVES "Timed Waves"
-#define RESPAWN_MODE_NAME_TICKETS "Tickets"
-#define RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS "Timed Waves, with Tickets"
-#define RESPAWN_MODE_NAME_TRIGGERED_WAVES "Triggered Waves"
-#define RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS "Triggered Waves, with Tickets"
+#include "../../respawn_macros.hpp"

--- a/components/briefing/macros.hpp
+++ b/components/briefing/macros.hpp
@@ -1,1 +1,9 @@
 #include "../../macros.hpp"
+
+#define RESPAWN_MODE_NAME_TIMED "Timed"
+#define RESPAWN_MODE_NAME_TIMED_TICKETS "Timed, with Tickets"
+#define RESPAWN_MODE_NAME_TIMED_WAVES "Timed Waves"
+#define RESPAWN_MODE_NAME_TICKETS "Tickets"
+#define RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS "Timed Waves, with Tickets"
+#define RESPAWN_MODE_NAME_TRIGGERED_WAVES "Triggered Waves"
+#define RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS "Triggered Waves, with Tickets"

--- a/respawn_macros.hpp
+++ b/respawn_macros.hpp
@@ -16,3 +16,11 @@
 #define RESPAWN_DEFAULTS "CAFE_FixPlayerTickets", "CAFE_WeaponSafety", "Counter", "CAFE_Loadout", "CAFE_Squad", "CAFE_MoveToSpawn"
 
 #define DEFAULT_RESPAWN_ARRAY {RESPAWN_DEFAULTS}
+
+#define RESPAWN_MODE_NAME_TIMED "Timed"
+#define RESPAWN_MODE_NAME_TIMED_TICKETS "Timed, with Tickets"
+#define RESPAWN_MODE_NAME_TIMED_WAVES "Timed Waves"
+#define RESPAWN_MODE_NAME_TICKETS "Tickets"
+#define RESPAWN_MODE_NAME_TIMED_WAVES_TICKETS "Timed Waves, with Tickets"
+#define RESPAWN_MODE_NAME_TRIGGERED_WAVES "Triggered Waves"
+#define RESPAWN_MODE_NAME_TRIGGERED_WAVES_TICKETS "Triggered Waves, with Tickets"


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add an entry to the briefing, containing the respawn settings for the mission, for the player's side.

### Release Notes
- Under the `Framework` part of the briefing, there is a new `Current Respawn Settings` entry.
- No configuration needed beyond what is already there for the respawn framework.
- Fields that are not defined for the respawn will be marked as "Not set"
- Covers:
  - Respawn mode (friendly-named, eg. `"Timed Waves, with Tickets"`)
  - Respawn Delay
  - Side tickets
  - player tickets

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes. Tested locally and on the server, for opfor, blufor, indfor, with various commbinations of respawn settings.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

