### PR TITLE
[Feature] Add Painkillers to gearscript crates

### DIFF
--- a/components/gearScript/crateSupport/fn_addMedsToCrate.sqf
+++ b/components/gearScript/crateSupport/fn_addMedsToCrate.sqf
@@ -11,10 +11,14 @@ if !(CRATE_VAR_EXISTS(_side,_crateName)) exitWith
 _crateArray = CRATE_VAR_DYNAMIC(_side,_crateName);
 
 _epiAmount = ceil (1/3 * _amount);
-_morphineAmount = floor (2/3 * _amount);
+_morphineAmount = floor (1/3 * _amount);
+_painkillerAmount = floor (1/3 * _amount);
 
 DEBUG_FORMAT3_LOG("[GEARSCRIPT-2]: Adding %1 epinephrine to crate type %2 for side %3.",_epiAmount,_crateName,_side)
 _crateArray pushBack ["ACE_epinephrine", _epiAmount];
 
 DEBUG_FORMAT3_LOG("[GEARSCRIPT-2]: Adding %1 morphine to crate type %2 for side %3.",_morphineAmount,_crateName,_side)
 _crateArray pushBack ["ACE_morphine", _morphineAmount];
+
+DEBUG_FORMAT3_LOG("[GEARSCRIPT-2]: Adding %1 painkillers to crate type %2 for side %3.",_epiAmount,_crateName,_side)
+_crateArray pushBack ["ACE_painkillers", _painkillerAmount];


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add Painkillers to gearscripted crates in addition to morphine and epinephrine (half the current morphine amount replaced by painkillers)

### Release Notes
Gearscripted crates now contain painkillers in addition to morphine and epinephrine (half the current morphine amount replaced by painkillers)


## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

