### PR TITLE
[Fix] - Transfer gravestone locality to prevent intransferable gear

### DIFF
--- a/components/gravestones/fn_createGravestoneAndDeleteCorpse.sqf
+++ b/components/gravestones/fn_createGravestoneAndDeleteCorpse.sqf
@@ -98,6 +98,11 @@ _createGravestone =
     [_grave, _corpse] call f_fnc_fillGraveAndDeleteCorpse;
     [_grave, _corpseName, _deathTime, _obituary] call f_fnc_sendGravestoneToClients;
 
+    _grave  addEventHandler ["ContainerOpened", {
+	    params ["_container", "_unit"];
+        _container setOwner (clientOwner _unit);
+    }];
+
 
 #else
 


### PR DESCRIPTION
added function to transfer grave locality ownership to accessing client

### Pull Request Description
**When merged this pull request will:**
Transfer locality ownership of grave containers to the accessing clients
Fix #226 


### Release Notes
Gravestone locality now transfered to opening client (no more non-accessible gravestones yayy)

## IMPORTANT

- [ ] Testing has been completed as neccessary, depending on the nature & impact of the changes.

**This is a untested draft which needs local and MP testing as well as testing related to what happens on multiple clients shlooting at the same time.**

- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

