### PR TITLE
[Feature] Change how respawns are added to groups

### DIFF
--- a/components/respawn/fn_forceJoinGroupByName.sqf
+++ b/components/respawn/fn_forceJoinGroupByName.sqf
@@ -1,0 +1,10 @@
+params ["_groupName"];
+
+private _group = allGroups select {groupId _x isEqualTo _groupName};
+
+if (count _group <= 0) exitWith {};
+
+diag_log format ["[CAFE Respawn]: Group in: %1", _groupName];
+diag_log format ["[CAFE Respawn]: %1 joinSilent %2", [player], (_group#0)];
+
+[player] joinSilent (_group#0);

--- a/components/respawn/fn_storePlayerGroup.sqf
+++ b/components/respawn/fn_storePlayerGroup.sqf
@@ -1,0 +1,10 @@
+params [["_oldGroup", grpNull]];
+
+if ((_oldGroup isEqualTo grpNull) or {!(_oldGroup isEqualType grpNull)}) then
+{
+	_oldGroup = group player;
+};
+
+diag_log format ["[CAFE Respawn]: Storing old group for player %1: %2", player, _groupName];
+
+f_var_lastPlayerGroupName = groupId _oldGroup;

--- a/components/respawn/fn_storePlayerGroup.sqf
+++ b/components/respawn/fn_storePlayerGroup.sqf
@@ -5,6 +5,6 @@ if ((_oldGroup isEqualTo grpNull) or {!(_oldGroup isEqualType grpNull)}) then
 	_oldGroup = group player;
 };
 
-diag_log format ["[CAFE Respawn]: Storing old group for player %1: %2", player, _groupName];
+diag_log format ["[CAFE Respawn]: Storing old group for player %1: %2", player, groupId _oldGroup];
 
 f_var_lastPlayerGroupName = groupId _oldGroup;

--- a/components/respawn/functions.hpp
+++ b/components/respawn/functions.hpp
@@ -2,8 +2,10 @@ class respawn
 {
     file = "components\respawn";
     class addFreeTicket{};
+    class forceJoinGroupByName{};
     class getPlayerRespawnDelay{};
     class isRespawnModeActive{};
+    class storePlayerGroup{postInit=1;};
 };
 class respawn_locationSystem
 {

--- a/components/respawn/squad/onPlayerKilled.sqf
+++ b/components/respawn/squad/onPlayerKilled.sqf
@@ -14,8 +14,9 @@ if (isNull _oldUnit) exitWith
 };
 
 DEBUG_FORMAT2_CHAT("[RESPAWN-2]: Removing %1 from squad %2.", _oldUnit, (group _oldUnit))
-
 private _oldGroup = group _oldUnit;
+
+[_oldGroup] call f_fnc_storePlayerGroup;
 [_oldUnit] joinSilent grpNull;
 
 // Wait until unit has properly joined new 'respawn' group and then make it invisible on the map.

--- a/components/respawn/squad/onPlayerRespawn.sqf
+++ b/components/respawn/squad/onPlayerRespawn.sqf
@@ -12,6 +12,7 @@ params ["_newUnit", "_oldUnit", "_respawn", "_respawnDelay"];
 private _didFirstSpawn = missionNamespace getVariable ["f_var_squad_didFirstSpawn", false];
 missionNamespace setVariable ["f_var_squad_didFirstSpawn", true];
 
+
 // If not JIP or first spawn, need to reapply gearscript after group is selected.  Apply a grace period of 60s in case group assignment goes wrong.
 f_fnc_respawn_squad_enforceLoadoutGracePeriod = 
 {
@@ -33,25 +34,38 @@ f_fnc_respawn_squad_enforceLoadoutGracePeriod =
 	] call CBA_fnc_waitAndExecute;
 };
 
-if (didJip or ((!didJip) and _didFirstSpawn)) exitWith 
+[] call f_fnc_respawn_squad_enforceLoadoutGracePeriod;
+
+
+private _playerGroup = missionNamespace getVariable ["f_var_lastPlayerGroupName", ""];
+
+if (_didFirstSpawn and {_playerGroup isNotEqualTo ""}) then 
 {
-	#ifdef ALLOW_TELEPORT_UPON_RESPAWN
-
-	player setVariable ["f_var_mayTeleportToGroup", true, true];
-
-	#endif
-
-	[] call f_fnc_respawn_squad_enforceLoadoutGracePeriod;
-
-	f_var_groupPicker_disableCancel = true;
-
-	// Wait a second to show the dialog, because timing issues can sometimes cause it to show up in the spectator screen, and then be subsequently destroyed.
 	[
 		{
-			createDialog "CAFE_GroupPicker_Dialog";
+			_this call f_fnc_forceJoinGroupByName;
+			
+			[
+				{_this call f_fnc_reapplyGear},
+				[player],
+				1
+			] call CBA_fnc_waitAndExecute;
 		},
-		[],
-		1
+		[_playerGroup],
+		5
 	] call CBA_fnc_waitAndExecute;
-	
 };
+
+
+#ifdef ALLOW_TELEPORT_UPON_RESPAWN
+
+if (didJip or ((!didJip) and _didFirstSpawn)) exitWith 
+{
+	player setVariable ["f_var_mayTeleportToGroup", true, true];
+};
+
+#endif
+
+
+// Load-bearing nil - Arma throws a "GIAS stack error" if this isn't here.
+nil


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Remove the need for players to choose their group upon respawn.

### Release Notes
The framework now remembers which group a player was in when they died, and puts them back when they respawn.  This should help with some respawn radio issues - players wouldn't get their group's radios if they didn't join their group.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
  - Tested during "Op Seabound" on 2025-01-05.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

