### PR TITLE
[Fix] - Fixed our squad radio integration with ACRE's ACE actions.

### DIFF
--- a/components/functions.hpp
+++ b/components/functions.hpp
@@ -72,7 +72,7 @@ class ace_gunbag
 };
 
 
-#if __has_include("\idi\acre\addons\main\stringtable.xml")
+#if __has_include("\idi\acre\addons\ace_interact\fnc_radioListChildrenActions.sqf")
     class acre_ace_interact
     {
         class overrides


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
Fix our squad radio integration with ACRE's ACE actions.
We used to use the stringtable as it should indicate whether ACRE is present.  `fileExists` and `__has_include` now do not detect it for some reason.
Resolves #243 

### Release Notes
Fixed our squad radio integration with ACRE's ACE actions.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

