### PR TITLE
[Fix] - Radio replacement script error with nested weapons

### DIFF
--- a/components/radio/acre/fn_acre_getAllRadiosForUnit.sqf
+++ b/components/radio/acre/fn_acre_getAllRadiosForUnit.sqf
@@ -66,3 +66,4 @@ private _radios = [];
 [_vest, _radios] call _findRadios;
 [_backpack, _radios] call _findRadios;
 
+_radios

--- a/components/radio/acre/fn_acre_getAllRadiosForUnit.sqf
+++ b/components/radio/acre/fn_acre_getAllRadiosForUnit.sqf
@@ -11,7 +11,13 @@ private _findRadiosNoConvert =
     if (_container isEqualTo []) exitWith {_retArray};
 
     {
-        private _name = _x#0;
+        _x params [
+            ["_name", "", ["", []]]
+        ];
+
+        if !(_name isEqualType "") then {
+            continue;
+        };
         if ([_name] call acre_api_fnc_isBaseRadio or {[_name] call acre_api_fnc_isRadio}) then
         {
             _retArray pushBack _name;
@@ -29,7 +35,13 @@ private _findRadiosAndConvert =
     if (_container isEqualTo []) exitWith {_retArray};
 
     {
-        private _name = _x#0;
+        _x params [
+            ["_name", "", ["", []]]
+        ];
+
+        if !(_name isEqualType "") then {
+            continue;
+        };
         if ([_name] call acre_api_fnc_isBaseRadio or {[_name] call acre_api_fnc_isRadio}) then
         {
             _retArray pushBack ([_name] call acre_api_fnc_getBaseRadio);
@@ -54,4 +66,3 @@ private _radios = [];
 [_vest, _radios] call _findRadios;
 [_backpack, _radios] call _findRadios;
 
-_radios

--- a/components/radio/acre/fn_acre_removeRadiosFromLoadout.sqf
+++ b/components/radio/acre/fn_acre_removeRadiosFromLoadout.sqf
@@ -11,7 +11,14 @@ private _filterOutRadios =
     private _retArray = [];
 
     {
-        private _name = _x#0;
+        _x params [
+            ["_name", "", ["", []]]
+        ];
+
+        if !(_name isEqualType "") then {
+            _retArray pushBack _x;
+            continue;
+        };
         if !([_name] call acre_api_fnc_isBaseRadio or {[_name] call acre_api_fnc_isRadio}) then
         {
             _retArray pushBack _x;


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Fix radio replacement script error with nested weapon arrays inside of loadouts (no type check was performed)

The associated issue was reported by KRATOS, who encountered it while using spare AT launchers in his loadout arrays:
![image](https://github.com/user-attachments/assets/f3abc830-bab9-4f5a-b4ae-3bbfc2c3a706)

I'm open to suggestions regarding the readability of my implementation. The current method uses `params` to perform an initial type check (arrays and strings are valid element types within a loadout container so we accept both; anything else will generate a script error, which is good because it indicates a loadout error), and then performs an additional check for the type that we care about (string) using `isEqualType` (which does not generate any script error at this stage).

### Release Notes
- Fixed a script error when using loadouts that contain nested weapons (e.g. breacher shotgun/spare disposable LAT inside of a backpack)

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

