### PR TITLE
Feature - Add Vehicle Gunner Stats

### DIFF
--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -10,27 +10,13 @@ if (hasInterface) then
 	["ace_firedPlayer", 
 	{
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-
-		if (_unit == player) then 
-		{
-			private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
-			private _currentCount = cafe_playerShots getOrDefault [_magName, 0];
-			private _updated = _currentCount + 1;
-			cafe_playerShots set [_magName, _updated];
-		};
+		[_magazine, true, _unit] call f_fnc_handleFiredEvent;
 	}] call CBA_fnc_addEventHandler;
 
 	["ace_firedPlayerVehicle", 
 	{
 		params ["_vehicle", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-
-		if (_unit == player) then 
-		{
-			private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
-			private _currentCount = cafe_playerShots getOrDefault [_magName, 0];
-			private _updated = _currentCount + 1;
-			cafe_playerShots set [_magName, _updated];
-		};
+		[_magazine, false, nil] call f_fnc_handleFiredEvent;
 	}] call CBA_fnc_addEventHandler;
 
 	["ace_unconscious", 

--- a/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
+++ b/components/statsTracking/fn_addStatsEventHandlersToClass.sqf
@@ -20,6 +20,19 @@ if (hasInterface) then
 		};
 	}] call CBA_fnc_addEventHandler;
 
+	["ace_firedPlayerVehicle", 
+	{
+		params ["_vehicle", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
+
+		if (_unit == player) then 
+		{
+			private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
+			private _currentCount = cafe_playerShots getOrDefault [_magName, 0];
+			private _updated = _currentCount + 1;
+			cafe_playerShots set [_magName, _updated];
+		};
+	}] call CBA_fnc_addEventHandler;
+
 	["ace_unconscious", 
 	{
 		params ["_unit", "_state"];

--- a/components/statsTracking/fn_handleFiredEvent.sqf
+++ b/components/statsTracking/fn_handleFiredEvent.sqf
@@ -1,0 +1,13 @@
+// Handles adding to the player's stats 
+// The second and third parameters are used to verify (if possible) that the player this is called for 
+// is in fact the local player. Set to false, nil if you don't want to/can't do that check. 
+params ["_magazine", "_verifyIsPlayer", "_unit"];
+
+if (_verifyIsPlayer) then {
+	if !(_unit isEqualTo player) exitWith {};
+};
+
+private _magName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
+private _currentCount = cafe_playerShots getOrDefault [_magName, 0];
+private _updated = _currentCount + 1;
+cafe_playerShots set [_magName, _updated];

--- a/components/statsTracking/functions.hpp
+++ b/components/statsTracking/functions.hpp
@@ -1,5 +1,9 @@
 class statsTracking
 {
     file = "components\statsTracking";
-    class addStatsEventHandlersToClass {};
+    class addStatsEventHandlersToClass {
+    };
+    class handleFiredEvent
+    {
+    };
 };

--- a/components/statsTracking/functions.hpp
+++ b/components/statsTracking/functions.hpp
@@ -1,9 +1,6 @@
 class statsTracking
 {
     file = "components\statsTracking";
-    class addStatsEventHandlersToClass {
-    };
-    class handleFiredEvent
-    {
-    };
+    class addStatsEventHandlersToClass {};
+    class handleFiredEvent {};
 };


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Show vehicle gunner ammunition usage on the stats screen
  - Note: this may grant "ammunition usage" to all users in the vehicle at the time the weapon fires; not just the gunner.

### Release Notes
- No changes required for mission makers.

## IMPORTANT

- [x] Testing has been completed as necessary, depending on the nature & impact of the changes. *Needs a check with a second person, to verify whether the stats are granted to all crew or just the gunner. This isn't a breaking thing though.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

