### PR TITLE
[Fix] Accidental modification of gearscript base loadout arrays.

### DIFF
--- a/components/gearScript/fn_applyLoadout.sqf
+++ b/components/gearScript/fn_applyLoadout.sqf
@@ -88,11 +88,12 @@ if ((_loadout isEqualType "") and (isPlayer _unit)) exitWith
 
 if (_loadout isEqualType []) then
 {
-    private _originalLoadout = +_loadout;
-    _originalLoadout = [_originalLoadout] call f_fnc_normaliseCbaExtendedLoadout;
+    private _copiedLoadout = +_loadout;
+    _copiedLoadout = [_copiedLoadout] call f_fnc_normaliseCbaExtendedLoadout;
 
-    _extendedArray = _originalLoadout#1;
-
+    _loadout = _copiedLoadout#0;
+    _extendedArray = _copiedLoadout#1;
+    
 
     if (count HATS_DYNAMIC(_gearVariant,_typeofUnit) > 0) then
     {

--- a/components/radio/acre/fn_acre_removeRadiosFromLoadout.sqf
+++ b/components/radio/acre/fn_acre_removeRadiosFromLoadout.sqf
@@ -8,7 +8,7 @@ if !(_loadout isEqualType []) exitWith {};
 
 private _filterOutRadios =
 {
-    if (_this isEqualTo []) exitWith {};
+    if (_this isEqualTo []) exitWith {[]};
 
     private _retArray = [];
 


### PR DESCRIPTION
I added some code to prevent the gearscript arrays being modified by the gear randomisation and pre/post hooks.  However the code doesn't work if it's written wrong.  oopsie

### Pull Request Description
**When merged this pull request will:**
- Fix accidental modification of gearscript base loadout arrays.
- Also fix cases where parts of a gearscript are missing (e.g. backpack).

### Release Notes
Fixed a bug in gearscript where the loadouts could slightly change over time.
Also fixed a problem in gear with missing backpacks etc.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

