### PR TITLE
[Fix] Documentation error in ACRE Config

### DIFF
--- a/configuration/acre_radio_configuration.sqf
+++ b/configuration/acre_radio_configuration.sqf
@@ -71,7 +71,7 @@
                 ["_radio", "_channelName", "_side", "_role", "_groupName"];
             Example:
                 // Gives short-range radios only to riflemen in the BLUFOR SPECOPS group, tuned to "COOL NET"
-                ["ACRE_PRC343", "COOL NET", west, "rif", "SPECOPS"] call f_fnc_acre_giveRadioToAllInGroup;
+                ["ACRE_PRC343", "COOL NET", west, "rif", "SPECOPS"] call f_fnc_acre_giveRadioToRoleInGroup;
 
         f_fnc_acre_removeRadioFromAllInRole
             Takes away a radio from every unit with the given role on the given side.


### PR DESCRIPTION
Documentation section regarding `giveRadioToRoleInGroup` function had an example which used `giveRadioToAllInGroup` instead.

### Pull Request Description
**When merged this pull request will:**
- _Fix documentation error in the ACRE config by replacing the example function to match the function being described._

### Release Notes
_Fixed documentation error in ACRE config_

## IMPORTANT

- [x] Testing has been completed as necessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

