### PR TITLE
[Fix] Zeus spawner UI toggles when backspacing in the search bar

### DIFF
--- a/components/zeus_ui/events/ui_init.sqf
+++ b/components/zeus_ui/events/ui_init.sqf
@@ -348,8 +348,12 @@ case "ui_init": {
 			_zeusUI displayAddEventHandler ["KeyDown", {
 				params ["_zeusUI", "_key"];
 
-				// If the backspace key was pressed, toggle the UI visibility
-				if (_key == 14) then {
+				// Grab the type of the focused control
+				// 2 = CT_EDIT, such as the search bar
+				_focusedCtrlType = ctrlType focusedCtrl _zeusUI;
+
+				// If the backspace key was pressed outside of a text edit control, toggle the UI visibility
+				if (_key == 14 && _focusedCtrlType != 2) then {
 
 					// Only detect the first keyDown event (so that holding down the key doesn't toggle the UI every frame)
 					if !(_zeusUI getVariable [MACRO_VARNAME_UI_SHOULDHIDE_KEYDOWN, false]) then {


### PR DESCRIPTION
Previously, the zeus spawner UI would toggle when you pressed backspace while typing in the search bar. This would lead to its visibility being opposite that of the rest of the UI. 

I tested all the ways I could think of. If you hold backspace while not in Zeus and then press Y, it gets a little wonky, but that's a different bug not introduced by this change. 

### Pull Request Description
**When merged this pull request will:**
- Make the zeus spawner UI ignore backspaces when a search bar is focused

### Release Notes
_Zeus spawner UI no longer toggles when backspacing in the search bar_

## IMPORTANT

- [x] Testing has been completed as necessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

