### PR TITLE
[Fix] Ignore tab input when alt-tabbing out of Zeus UI

### DIFF
--- a/components/zeus_ui/events/ui_init.sqf
+++ b/components/zeus_ui/events/ui_init.sqf
@@ -1,3 +1,4 @@
+#include "\a3\ui_f\hpp\definedikcodes.inc"
 // Initialisation
 case "ui_init": {
 	_eventExists = true;
@@ -346,7 +347,7 @@ case "ui_init": {
 
 			// Hide the UI when pressing backspace
 			_zeusUI displayAddEventHandler ["KeyDown", {
-				params ["_zeusUI", "_key"];
+				params ["_zeusUI", "_key", "_shift", "_ctrl", "_alt"];
 
 				// If the backspace key was pressed, toggle the UI visibility
 				if (_key == 14) then {
@@ -360,6 +361,10 @@ case "ui_init": {
 
 						["ui_toggle", [_isShown]] call f_fnc_zeusUI;
 					};
+				};
+
+				if (_key isEqualTo DIK_TAB && _alt) then {
+					true
 				};
 			}];
 			_zeusUI displayAddEventHandler ["KeyUp", {

--- a/components/zeus_ui/events/ui_init.sqf
+++ b/components/zeus_ui/events/ui_init.sqf
@@ -363,6 +363,7 @@ case "ui_init": {
 					};
 				};
 
+				// Ignore alt-tab to avoid shifting spawn menu over one category
 				if (_key isEqualTo DIK_TAB && _alt) then {
 					true
 				};


### PR DESCRIPTION
Previously, if you alt tabbed out of the zeus UI it would shift over one category. Now, it doesn't. 

I'm not sure if this one is too specific. It's a minor inconvenience but nice to fix. I'm worried it could cause problems if somebody has a super wack setup. Feel free to ignore if the minor improvement is not worth the minor risk. 

### Pull Request Description
**When merged this pull request will:**
- Add to the keydown event handler to catch any alt-tab inputs and not process them

### Release Notes
Alt-tabbing out of Zeus UI no longer shifts the spawn bar over by one category

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

