### PR TITLE
[Change] Hide FT markers on map when toggled

### DIFF
--- a/components/ftMemberMarkers/fn_drawFireteamMarkers.sqf
+++ b/components/ftMemberMarkers/fn_drawFireteamMarkers.sqf
@@ -5,7 +5,11 @@ params ["_map"];
 if !(alive player) exitWith {};
 if !IS_TRUE(f_var_allSettingsReady) exitWith {};
 
+#ifdef HIDE_DEAD_IN_SQUAD
 _group = (units player) select {alive _x};
+#else
+_group = units player;
+#endif
 _baseIcon = "\A3\ui_f\data\map\vehicleicons\iconMan_ca.paa";
 
 


### PR DESCRIPTION
Addition to #279 to keep fireteam markers on the map when HIDE_DEAD_IN_SQUAD is turned off. 

### Pull Request Description
**When merged this pull request will:**
- Hide fireteam markers from the map when HIDE_DEAD_IN_SQUAD is on, mirroring previous behavior
- Keep fireteam markers on the map when HIDE_DEAD_IN_SQUAD is off

### Release Notes
Keeps a player's marker on the map even if they are dead, if the mission maker has turned off hiding dead players in squads.

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

