### PR TITLE
[Change] Use CBA setting to set custom radar sort type

### DIFF
--- a/components/cbaSettings/dui_settings.sqf
+++ b/components/cbaSettings/dui_settings.sqf
@@ -1,0 +1,1 @@
+force diwako_dui_radar_sortType = "custom";

--- a/components/cbaSettings/settings.sqf
+++ b/components/cbaSettings/settings.sqf
@@ -5,6 +5,7 @@
 -------------------------------------------------------------------------------------------------------------------- */
 
 #include "..\..\configuration\cbaSettings.hpp"
+#include "..\..\configuration\respawn.hpp"
 
 //Medical
 
@@ -65,5 +66,12 @@
 #ifdef DISABLE_ACE_CAR_DAMAGE
 
 	#include "ace_vic_settings.sqf"
+
+#endif
+
+// Diwako DUI squad radar
+#ifdef HIDE_DEAD_IN_SQUAD
+
+	#include "dui_settings.sqf"
 
 #endif

--- a/components/respawn/init_component.sqf
+++ b/components/respawn/init_component.sqf
@@ -267,13 +267,6 @@ if (hasInterface) then
         };
 
         diwako_dui_radar_sortType = "custom";
-
-        // Set the sort type again. Something resets it to "none" on clients on mission start.
-        [
-            {diwako_dui_radar_sortType isNotEqualTo "custom"},
-            {missionNamespace setVariable ["diwako_dui_radar_sortType", "custom"]; DEBUG_PRINT_LOG("[RESPAWN] Detected non-custom sort type. setting to custom.")},
-            []
-        ] call CBA_fnc_waitUntilAndExecute;
     };
 
     f_var_hidingDeadPlayers = true;


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add a CBA settings file for diwako DUI to set the radar sort type to "custom"
- Remove the other way of doing it which was forcing it back to custom after the CBA setting applied

### Release Notes
Small change to use CBA settings to hide dead players from DUI radar

## IMPORTANT

- [ ] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

