### PR TITLE
[Fix] Leadership info in respawn briefing doesn't match settings

### DIFF
--- a/components/briefing/briefings/ca_briefing_respawn.sqf
+++ b/components/briefing/briefings/ca_briefing_respawn.sqf
@@ -20,8 +20,8 @@ private _modeName = "Not set";
 private _sideTickets = "Not set";
 private _individualTickets = "Not set";
 private _hideDeadPlayersString = ["<font color='#FF5555'>will remain visible</font> on", "are removed from"] select _hideDeadPlayersInSquad;
-private _leadershipTransfer = ["is transferred", "is not transferred"] select _hideDeadPlayersInSquad;
-private _leadershipReturn = [" and given back upon TP", ""] select (_allowTeleportUponRespawn and _hideDeadPlayersInSquad);
+private _leadershipTransfer = ["is not transferred", "is transferred"] select _hideDeadPlayersInSquad;
+private _leadershipReturn = ["", " and given back upon TP"] select (_allowTeleportUponRespawn and _hideDeadPlayersInSquad);
 private _mode = "";
 
 if (_side == west) then {


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Make the respawn briefing have the correct info regarding leadership transfer on death and TP

### Release Notes
Fixes respawn briefing text regarding group leadership transfer on death and TP. 

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

