### PR TITLE
[Fix] - Change respawn point listing logic

### DIFF
--- a/components/respawn/fn_getAvailableRespawns.sqf
+++ b/components/respawn/fn_getAvailableRespawns.sqf
@@ -1,0 +1,63 @@
+// get all spawn positions available to the given target (OBJECT, GROUP, SIDE or NAMESPACE)
+// gotchas: doesn't support "leading side" or vehicles
+
+params ["_target"];
+
+private _fnc_logicAvailableToTarget = 
+{
+	params ["_logic", "_target"];
+
+	private _sideId = _logic getVariable ["side", -1];
+	private _typeId = _logic getVariable ["type", -1];
+
+	if (_typeId > 0) exitWith { false };
+
+	if (_target isEqualTypeAny [objNull, grpNull]) then
+	{
+		_target = side _target;
+	};
+
+	if (_target isEqualType sideEmpty) exitWith
+	{
+		(_sideId < 0) or {_sideId isEqualTo (_target call bis_fnc_sideID)}
+	};
+	
+	(_sideId < 0)
+};
+
+private _fnc_markerAvailableToTarget = 
+{
+	params ["_markerName", "_target"];
+
+	if (_target isEqualTypeAny [objNull, grpNull]) then
+	{
+		_target = side _target;
+	};
+
+	if (_target isEqualType sideEmpty) exitWith
+	{
+		private _sideString = ["east", "west", "guer", "civ"] select (_target call bis_fnc_sideID)
+		(_markerName find ("respawn_" + sideString) >= 0)
+	};
+};
+
+private _candidateMarkers = allMapMarkers; // Don't pre-filter, extra string searches for no reason.
+
+private _availableMarkers = _candidateMarkers select {[_x, _target] call _fnc_markerAvailableToTarget};
+
+switch (typename _target) do {
+	case (typename objnull): {
+		_objectPositions = if (isnull _target) then {_default} else {_target getvariable [_varName,_default]};
+		_groupPositions = if (isnull group _target) then {_default} else {(group _target) getvariable [_varName,_default]};
+		_sidePositions = missionnamespace getvariable [_varName + str (_target call bis_fnc_objectSide),_default];
+	};
+	case (typename grpnull): {
+		_groupPositions = if (isnull _target) then {_default} else {(_target) getvariable [_varName,_default]};
+		_sidePositions = missionnamespace getvariable [_varName + str (_target call bis_fnc_objectSide),_default];
+	};
+	case (typename sideunknown): {
+		_sidePositions = missionnamespace getvariable [_varName + str (_target),_default];
+	};
+	case (typename missionnamespace): {
+	};
+};

--- a/components/respawn/fn_getAvailableRespawns.sqf
+++ b/components/respawn/fn_getAvailableRespawns.sqf
@@ -1,5 +1,5 @@
 // get all spawn positions available to the given target (OBJECT, GROUP, SIDE or NAMESPACE)
-// gotchas: doesn't support "leading side" or vehicles
+// gotchas: doesn't support "leading side" or respawnable vehicles
 
 params ["_target"];
 
@@ -7,12 +7,21 @@ private _fnc_logicAvailableToTarget =
 {
 	params ["_logic", "_target"];
 
-	private _sideId = _logic getVariable ["side", -1];
-	private _typeId = _logic getVariable ["type", -1];
+	private _respawnLocations = (_logic getvariable "respawn");
 
-	if (_typeId > 0) exitWith { false };
+	if (isNil "_respawnLocations") exitWith { false }; // Respawn point disabled.
 
-	if (_target isEqualTypeAny [objNull, grpNull]) then
+	private _sideId = parseNumber (_logic getVariable ["side", "-1"]); // Id < 0 = "leading side".  We are interpreting as "any side" instead.
+	private _typeId = parseNumber (_logic getVariable ["type", "-1"]);
+
+	if (_typeId > 0) exitWith { false }; // Type is not "Infantry respawn".
+
+	if (_target isKindOf "CAManBase") then
+	{
+		_target = group _target;
+	};
+
+	if (_target isEqualType grpNull) then
 	{
 		_target = side _target;
 	};
@@ -29,35 +38,27 @@ private _fnc_markerAvailableToTarget =
 {
 	params ["_markerName", "_target"];
 
-	if (_target isEqualTypeAny [objNull, grpNull]) then
+	if (_target isKindOf "CAManBase") then
+	{
+		_target = group _target;
+	};
+
+	if (_target isEqualType grpNull) then
 	{
 		_target = side _target;
 	};
 
 	if (_target isEqualType sideEmpty) exitWith
 	{
-		private _sideString = ["east", "west", "guer", "civ"] select (_target call bis_fnc_sideID)
-		(_markerName find ("respawn_" + sideString) >= 0)
+		private _sideString = ["east", "west", "guer", "civ"] select (_target call bis_fnc_sideID);
+		(_markerName find ("respawn_" + _sideString) >= 0)
 	};
 };
 
 private _candidateMarkers = allMapMarkers; // Don't pre-filter, extra string searches for no reason.
-
 private _availableMarkers = _candidateMarkers select {[_x, _target] call _fnc_markerAvailableToTarget};
 
-switch (typename _target) do {
-	case (typename objnull): {
-		_objectPositions = if (isnull _target) then {_default} else {_target getvariable [_varName,_default]};
-		_groupPositions = if (isnull group _target) then {_default} else {(group _target) getvariable [_varName,_default]};
-		_sidePositions = missionnamespace getvariable [_varName + str (_target call bis_fnc_objectSide),_default];
-	};
-	case (typename grpnull): {
-		_groupPositions = if (isnull _target) then {_default} else {(_target) getvariable [_varName,_default]};
-		_sidePositions = missionnamespace getvariable [_varName + str (_target call bis_fnc_objectSide),_default];
-	};
-	case (typename sideunknown): {
-		_sidePositions = missionnamespace getvariable [_varName + str (_target),_default];
-	};
-	case (typename missionnamespace): {
-	};
-};
+private _candidateLogics = "ModuleRespawnPosition_F" allObjects 1; // BUB 2025-09-21 TODO :: cache this list with staleness timer
+private _availableLogics = _candidateLogics select {[_x, _target] call _fnc_logicAvailableToTarget};
+
+(_availableMarkers + _availableLogics)

--- a/components/respawn/fn_getRespawnName.sqf
+++ b/components/respawn/fn_getRespawnName.sqf
@@ -1,0 +1,44 @@
+// Get an appropriate name for the given spawn location.  Try to choose a decent fallback name if this isn't possible.
+
+params ["_spawn"];
+
+if (_spawn isEqualType objNull) exitWith
+{
+	private _name = "";
+
+	if (typeOf _spawn isEqualTo "ModuleRespawnPosition_F") then
+	{
+		_name = _spawn getvariable["Name", ""];
+	};
+
+	if (_spawn isKindOf "CAManBase" and (alive _spawn)) then
+	{
+		_name = name _spawn;
+	};
+
+	if (_spawn isKindOf "AllVehicles" and (alive _spawn)) then
+	{
+		_name = (getText (configFile >> "CfgVehicles" >> (typeOf _spawn) >> "displayName"));
+	};
+	
+	if (_name isEqualTo "") then
+	{
+		_name = ("Grid coordinates: " + mapGridPosition _spawn);
+	};
+
+	_name
+};
+
+if (_spawn isEqualType "") exitWith
+{
+	private _markerPos = getMarkerPos _spawn;
+
+	if (_markerPos isNotEqualTo [0,0,0]) exitWith
+	{
+		("Grid coordinates: " + mapGridPosition _markerPos)
+	};
+
+	_spawn
+};
+
+str _spawn

--- a/components/respawn/functions.hpp
+++ b/components/respawn/functions.hpp
@@ -3,7 +3,9 @@ class respawn
     file = "components\respawn";
     class addFreeTicket{};
     class forceJoinGroupByName{};
+    class getAvailableRespawns{};
     class getPlayerRespawnDelay{};
+    class getRespawnName{};
     class isRespawnModeActive{};
     class storePlayerGroup{postInit=1;};
     class leaderTagLoop{};

--- a/components/respawn/ui_functions/spawnPickerDialog/fn_spawnPickerDialog_populateDialog.sqf
+++ b/components/respawn/ui_functions/spawnPickerDialog/fn_spawnPickerDialog_populateDialog.sqf
@@ -10,8 +10,8 @@ params ["_display"];
 /*
     ==== Spawns List ====
 */
-private _spawns = (player call bis_fnc_getRespawnPositions) + ((player call bis_fnc_objectSide) call bis_fnc_getRespawnMarkers);
-private _spawnListEntries = _spawns apply {[_x, (_x call BIS_fnc_showRespawnMenuPositionName) # 0]};
+private _spawns = [player] call f_fnc_getAvailableRespawns;
+private _spawnListEntries = _spawns apply {[_x, _x call f_fnc_getRespawnName]};
 // Markers have the name "_respawnMarker<index>"
 private _spawnMarkers = [];
 

--- a/components/respawn/ui_functions/spawnPickerDialog/fn_spawnPickerDialog_updateLoop.sqf
+++ b/components/respawn/ui_functions/spawnPickerDialog/fn_spawnPickerDialog_updateLoop.sqf
@@ -29,8 +29,8 @@ if (!(missionNamespace getVariable ["f_var_spawnPickerDialog_isOpened", false]))
 };
 
 // Find the location of all of the respawns
-private _spawns = (player call bis_fnc_getRespawnPositions) + ((player call bis_fnc_objectSide) call bis_fnc_getRespawnMarkers);
-private _spawnListEntries = _spawns apply {[_x, (_x call BIS_fnc_showRespawnMenuPositionName) # 0]};
+private _spawns = [player] call f_fnc_getAvailableRespawns;
+private _spawnListEntries = _spawns apply {[_x, _x call f_fnc_getRespawnName]};
 private _spawnLocations = [];
 {
     switch (typeName _x) do {
@@ -115,7 +115,7 @@ if (_spawnsChanged) then {
     // Mark all respawn points
     {
         createMarkerLocal [_x, _spawnLocations # _forEachIndex];
-        _x setMarkerTypeLocal "flag_Denmark"; // respawn_inf
+        _x setMarkerTypeLocal "respawn_inf"; // respawn_inf
     } forEach _spawnMarkers;
 
     // Center the map over the selected respawn point


### PR DESCRIPTION
Resolves #277

### ⚠️ If the respawn point is linked to something (like a vehicle), the player probably won't respawn on that thing with this new implementation.  Needs to be resolved before taking this out of draft. ⚠️

### Pull Request Description
**When merged this pull request will:**
- Fix issue described in #277
- Not tested yet - probably needs another MP test or a live test on a Saturday mish.
- Changes the logic a little for which spawnpoints are considered eligible.  Probably worth a glance.

### Release Notes
Changed the way that the available respawn points are calculated for each player.  This should help cases where you select one place to spawn and you appear in a different place.

## IMPORTANT

- [ ] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [ ] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

