### PR TITLE
[Feature] - Add modules to manage Arma 3 Task Framework tasks

### DIFF
--- a/components/functions.hpp
+++ b/components/functions.hpp
@@ -30,6 +30,7 @@ class F
 #include "triggerSpawner\functions.hpp"
 #include "viewDistanceEditor\functions.hpp"
 #include "zeus_ui\functions.hpp"
+#include "taskings\functions.hpp"
 
 }
 

--- a/components/taskings/fn_tasking_create.sqf
+++ b/components/taskings/fn_tasking_create.sqf
@@ -1,0 +1,29 @@
+_taskList = player call BIS_fnc_tasksUnit;
+["Create Tasking", 
+	[
+		["SIDES", "Tasking for...", WEST], //_taskingSide
+		["EDIT", "Tasking Name/ID"], //_taskingName
+		["CHECKBOX", "Has parent?", false], //_hasParent
+		["COMBO", "Parent Tasking", [_taskList,_taskList]], //_parentTasking
+		["COMBO", "Initial State", [["CREATED", "ASSIGNED", "SUCCEEDED", "FAILED", "CANCELED"],["Created", "Assigned", "Succeeded", "Failed", "Cancelled"]]], //_initialState
+		["EDIT:MULTI", "Description"] //_taskingDescription
+	],
+	{
+		//On Confirm
+		params ["_dialogValues"];
+		_dialogValues params ["_taskingSide", "_taskingName", "_hasParent", "_parentTasking", "_initialState", "_taskingDescription"];
+		hint str _dialogValues;
+		if (_hasParent) then
+		{
+			hint "has parent";
+			[west, [_taskingName, _parentTasking], [_taskingDescription, _taskingName, "void"], objNull, _initialState] call BIS_fnc_taskCreate;
+		}
+		else
+		{
+			hint "does not have parent";
+			[_taskingSide, _taskingName, [_taskingDescription, _taskingName, "void"], objNull, _initialState] call BIS_fnc_taskCreate;
+		};
+	}, 
+	{},
+	[]
+] call zen_dialog_fnc_create;

--- a/components/taskings/fn_tasking_create.sqf
+++ b/components/taskings/fn_tasking_create.sqf
@@ -12,15 +12,12 @@ _taskList = player call BIS_fnc_tasksUnit;
 		//On Confirm
 		params ["_dialogValues"];
 		_dialogValues params ["_taskingSide", "_taskingName", "_hasParent", "_parentTasking", "_initialState", "_taskingDescription"];
-		hint str _dialogValues;
 		if (_hasParent) then
 		{
-			hint "has parent";
 			[west, [_taskingName, _parentTasking], [_taskingDescription, _taskingName, "void"], objNull, _initialState] call BIS_fnc_taskCreate;
 		}
 		else
 		{
-			hint "does not have parent";
 			[_taskingSide, _taskingName, [_taskingDescription, _taskingName, "void"], objNull, _initialState] call BIS_fnc_taskCreate;
 		};
 	}, 

--- a/components/taskings/fn_tasking_create.sqf
+++ b/components/taskings/fn_tasking_create.sqf
@@ -6,7 +6,7 @@ _taskList = player call BIS_fnc_tasksUnit;
 		["CHECKBOX", "Has parent?", false], //_hasParent
 		["COMBO", "Parent Tasking", [_taskList,_taskList]], //_parentTasking
 		["COMBO", "Initial State", [["CREATED", "ASSIGNED", "SUCCEEDED", "FAILED", "CANCELED"],["Created", "Assigned", "Succeeded", "Failed", "Cancelled"]]], //_initialState
-		["EDIT:MULTI", "Description"] //_taskingDescription
+		["EDIT:MULTI", "Task Description"] //_taskingDescription
 	],
 	{
 		//On Confirm

--- a/components/taskings/fn_tasking_remove.sqf
+++ b/components/taskings/fn_tasking_remove.sqf
@@ -1,0 +1,20 @@
+_taskList = player call BIS_fnc_tasksUnit;
+if (count _taskList > 0) then
+{
+    ["Remove Tasking", 
+        [
+            ["COMBO", "Task", [_taskList,_taskList]]
+        ],
+        {
+            params ["_dialogValues", "_arguments"];
+            _dialogValues params ["_taskName", "_taskState"];
+            [_taskName, true, true] call BIS_fnc_deleteTask;
+        }, 
+        {},
+        []
+    ] call zen_dialog_fnc_create;
+}
+else
+{
+    ["No Taskings to remove."] call zen_common_fnc_showMessage;
+};

--- a/components/taskings/fn_tasking_state.sqf
+++ b/components/taskings/fn_tasking_state.sqf
@@ -1,0 +1,21 @@
+_taskList = player call BIS_fnc_tasksUnit;
+if (count _taskList > 0) then
+{
+    ["Set Tasking State", 
+        [
+            ["COMBO", "Task", [_taskList,_taskList]],
+            ["COMBO", "State", [["CREATED", "ASSIGNED", "SUCCEEDED", "FAILED", "CANCELED"],["Created", "Assigned", "Succeeded", "Failed", "Cancelled"]]]
+        ],
+        {
+            params ["_dialogValues", "_arguments"];
+            _dialogValues params ["_taskName", "_taskState"];
+            [_taskName, _taskState] call BIS_fnc_taskSetState;
+        }, 
+        {},
+        []
+    ] call zen_dialog_fnc_create;
+}
+else
+{
+    ["No Taskings to list."] call zen_common_fnc_showMessage;
+};

--- a/components/taskings/functions.hpp
+++ b/components/taskings/functions.hpp
@@ -3,4 +3,5 @@ class taskings
     file = "components\taskings";
     class tasking_state{};
     class tasking_create{};
+    class tasking_remove{};
 }

--- a/components/taskings/functions.hpp
+++ b/components/taskings/functions.hpp
@@ -1,0 +1,6 @@
+class taskings
+{
+    file = "components\taskings";
+    class tasking_state{};
+    class tasking_create{};
+}

--- a/components/taskings/zen_modules.sqf
+++ b/components/taskings/zen_modules.sqf
@@ -15,4 +15,11 @@ call
             [] remoteExecCall ["f_fnc_tasking_state"];
         }
     ] call zen_custom_modules_fnc_register;
+    [
+        _category,
+        "Remove Tasking",
+        {
+            [] remoteExecCall ["f_fnc_tasking_remove"];
+        }
+    ] call zen_custom_modules_fnc_register;
 };

--- a/components/taskings/zen_modules.sqf
+++ b/components/taskings/zen_modules.sqf
@@ -1,0 +1,18 @@
+private _category = "[CAFE3] Taskings";
+call
+{
+    [
+        _category,
+        "Create Tasking",
+        {
+            [] remoteExecCall ["f_fnc_tasking_create"];
+        }
+    ] call zen_custom_modules_fnc_register;
+    [
+        _category,
+        "Set Tasking State",
+        {
+            [] remoteExecCall ["f_fnc_tasking_state"];
+        }
+    ] call zen_custom_modules_fnc_register;
+};

--- a/components/taskings/zen_modules.sqf
+++ b/components/taskings/zen_modules.sqf
@@ -1,25 +1,27 @@
-private _category = "[CAFE3] Taskings";
-call
-{
-    [
-        _category,
-        "Create Tasking",
-        {
-            [] remoteExecCall ["f_fnc_tasking_create"];
-        }
-    ] call zen_custom_modules_fnc_register;
-    [
-        _category,
-        "Set Tasking State",
-        {
-            [] remoteExecCall ["f_fnc_tasking_state"];
-        }
-    ] call zen_custom_modules_fnc_register;
-    [
-        _category,
-        "Remove Tasking",
-        {
-            [] remoteExecCall ["f_fnc_tasking_remove"];
-        }
-    ] call zen_custom_modules_fnc_register;
-};
+#ifdef USE_ZEUS_TASKING_MODULES 
+    private _category = "[CAFE3] Taskings";
+    call
+    {
+        [
+            _category,
+            "Create Tasking",
+            {
+                [] remoteExecCall ["f_fnc_tasking_create"];
+            }
+        ] call zen_custom_modules_fnc_register;
+        [
+            _category,
+            "Set Tasking State",
+            {
+                [] remoteExecCall ["f_fnc_tasking_state"];
+            }
+        ] call zen_custom_modules_fnc_register;
+        [
+            _category,
+            "Remove Tasking",
+            {
+                [] remoteExecCall ["f_fnc_tasking_remove"];
+            }
+        ] call zen_custom_modules_fnc_register;
+    };
+#endif

--- a/components/zen_modules.sqf
+++ b/components/zen_modules.sqf
@@ -7,3 +7,4 @@
 #include "respawn\zen_modules.sqf"
 #include "radio\zen_modules.sqf"
 #include "slottingGenerator\zen_modules.sqf"
+#include "taskings\zen_modules.sqf"

--- a/configuration/zeusTaskingModules.hpp
+++ b/configuration/zeusTaskingModules.hpp
@@ -1,0 +1,23 @@
+/*
+	Initial Task State ZEN module by Kennedy, development into on-the-fly Task Framework management by outsidecontextcass
+
+	Known limitations:
+	- Tasks lack icons
+	- Tasks lack destinations
+	- Only tasks of the same side as Zeus are listed
+
+	Features:
+	When enabled, the [CAFE3 Tasking] category appears with the following modules:
+
+	Create Tasking:
+	Allows Zeus to create an Arma 3 Task Framework task on the fly. The Owner side defaults to WEST, and the initial state to Created.
+	
+	Set Tasking State:
+	Allows Zeus to adjust the state of a task on the fly whether it's been created in Eden or as Zeus. The module uses the Task ID as a friendly name.
+
+	Remove Tasking:
+	Allows Zeus to delete a Task. May need running multiple times if a Task is synced to a specific group to first clear the assignment, then delete the Task itself.
+*/
+
+// Comment out to disable the CAFE3 Tasking modules
+#define USE_ZEUS_TASKING_MODULES

--- a/startup/configuration/internals/configMacros.hpp
+++ b/startup/configuration/internals/configMacros.hpp
@@ -18,3 +18,4 @@
 #include "..\..\..\configuration\respawn.hpp"
 #include "..\..\..\configuration\slottingGenerator.hpp"
 #include "..\..\..\configuration\statsTracking.hpp"
+#include "..\..\..\configuration\zeusTaskingModules.hpp"


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Close #160
- Adds ZEN category: [CAFE3] Taskings
- Adds ZEN module: Create Tasking
- Adds ZEN module: Change Tasking State
- Adds ZEN module: Remove Tasking

### Release Notes
Taskings provides simple Task management modules to Zeus to create, remove, and change states of Tasks during an op. The Change Tasking State and Remove Tasking modules can also manipulate Tasks created in Eden.

Tasking docs can be found in `configuration/zeusTaskingModules.hpp`, which also allows mission makers to disable the modules.

[BI's Arma 3 Task Framework documentation](https://community.bistudio.com/wiki/Arma_3:_Task_Framework)

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [X] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

