### PR TITLE
[Feature] Added Zeus Slot Short Codes to Slotting Generator

### DIFF
--- a/components/slottingGenerator/globals.sqf
+++ b/components/slottingGenerator/globals.sqf
@@ -75,8 +75,8 @@ f_map_slot_shortcodes = createHashMapFromArray
 	["zeus player", "ZEUS"],
 	["zeus player 1", "ZEUS"],
 	["zeus player 2", "ZEUS"],
-	["zeus", "ZEUS"]
-	["zeus 1", "ZEUS"]
+	["zeus", "ZEUS"],
+	["zeus 1", "ZEUS"],
 	["zeus 2", "ZEUS"]
 ];
 

--- a/components/slottingGenerator/globals.sqf
+++ b/components/slottingGenerator/globals.sqf
@@ -71,7 +71,13 @@ f_map_slot_shortcodes = createHashMapFromArray
 	["sniper", "SN"],
 	["spotter", "SPOT"],
 	["marksman", "MK"],
-	["designated marksman", "MK"]
+	["designated marksman", "MK"],
+	["zeus player", "ZEUS"],
+	["zeus player 1", "ZEUS"],
+	["zeus player 2", "ZEUS"],
+	["zeus", "ZEUS"]
+	["zeus 1", "ZEUS"]
+	["zeus 2", "ZEUS"]
 ];
 
 f_map_slot_icons = createHashMapFromArray


### PR DESCRIPTION
### Added Zeus Slot Short Codes to the Slotting Generator
**When merged this pull request will:**
- _Add common Zeus role descriptions to the slotting generator slot short codes. Cause some of us like having Zeus slots on the slotting site._

### Release Notes
_Added Zeus Role Descriptions to the default Slotting Generator Slot Short Codes_

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

