### PR TITLE
[Fix] Dead players are removed from radar

### DIFF
--- a/components/respawn/init_component.sqf
+++ b/components/respawn/init_component.sqf
@@ -266,6 +266,26 @@ if (hasInterface) then
         diwako_dui_radar_sortType = "custom";
     };
 
+    // Code which is run each frame after DUI draws the radar
+    diwako_dui_custom_code = {
+        /*
+            1. Display of the RscTile
+            2. Control of the compass
+            3. Control of the bearing indicator
+            4. Control group of the units displayed on the compass
+            5. All currently shown unit icons on the compass
+        */
+        params ["", "", "", "_unitsCtrlGrp"];
+        
+        private _deadPlayers = (units player) select {!alive _x};
+        
+        private _deadPlayerIDs = (_deadPlayers) apply {_x getVariable ["diwako_dui_unit_id", nil]};
+        
+        {
+            ctrlDelete (_unitsCtrlGrp getVariable [format ["diwako_dui_ctrl_unit_%1", _x], controlNull]);
+        } forEach _deadPlayerIDs; 
+    };
+
     f_var_hidingDeadPlayers = true;
 
     #endif


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- _Make it so dead players are removed from DUI radar_

### Release Notes
_Dead players are removed from the DUI radar when the option is turned on by the mission maker._

this probably doesn't need patch notes it just makes it work like it did before.

Closes #296 

## IMPORTANT

- [ ] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

