### PR TITLE
[Feature] Fix radio bug at mission start and add ranks to non-BLUFOR players

### DIFF
--- a/components/gearScript/fn_assignGear.sqf
+++ b/components/gearScript/fn_assignGear.sqf
@@ -1,5 +1,11 @@
 #include "macros.hpp"
 
+// Overwrite the EDEN Editor ACRE radio settings to be empty
+// This line runs more often than is necessary but it has to go here for timing reasons.
+// It has to be set after expressions of EDEN entity attributes are called but before postInit happens.
+// It will also run every time gearscript happens but that's the cost of doing business.
+(_this select 1) setVariable ["acre_sys_radio_setup", "[]"];
+
 RUN_AS_ASYNC(f_fnc_assignGear);
 
 // ====================================================================================

--- a/mission.sqm
+++ b/mission.sqm
@@ -20,7 +20,7 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=2;
+		nextID=4;
 	};
 	class Camera
 	{
@@ -9503,6 +9503,7 @@ class Mission
 					flags=3;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""co"", this] call f_fnc_assignGear;" \n "this setVariable [""f_leaderGroup"", true]";
 						description="Commander@TANGO";
 						isPlayable=1;
@@ -9538,7 +9539,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -9546,12 +9560,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={549.27368,5.0014391,253.67612};
+						position[]={549.27399,5.0014391,253.67601};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""co"", this] call f_fnc_assignGear;";
 						description="Executive Officer";
 						isPlayable=1;
@@ -9587,7 +9602,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item2
@@ -9595,12 +9623,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={552.51367,5.0014391,252.35312};
+						position[]={552.51398,5.0014391,252.353};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""fac"", this] call f_fnc_assignGear;";
 						description="Forward Air Controller";
 						isPlayable=1;
@@ -9636,7 +9665,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -9644,12 +9686,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={541.75763,5.0014391,256.62408};
+						position[]={541.758,5.0014391,256.62399};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -9685,7 +9728,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item4
@@ -9693,12 +9749,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={544.77863,5.0014391,255.3261};
+						position[]={544.77899,5.0014391,255.326};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""med"", this] call f_fnc_assignGear;";
 						description="Medic";
 						isPlayable=1;
@@ -9747,7 +9804,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item5
@@ -9755,12 +9825,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={545.75763,5.0014391,250.79712};
+						position[]={545.758,5.0014391,250.797};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""eng"", this] call f_fnc_assignGear;";
 						description="Logistics";
 						isPlayable=1;
@@ -9809,7 +9880,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item6
@@ -9817,12 +9901,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={544.70764,5.0014391,248.03111};
+						position[]={544.70801,5.0014391,248.03101};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""eng"", this] call f_fnc_assignGear;";
 						description="Logistics";
 						isPlayable=1;
@@ -9871,7 +9956,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 			};
@@ -9911,12 +10009,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={514.75262,5.0014391,291.70111};
+						position[]={514.75299,5.0014391,291.70099};
 					};
 					side="East";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@TANGO-1";
 						isPlayable=1;
@@ -9952,7 +10051,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -9960,12 +10072,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={512.18091,5.0014391,284.77222};
+						position[]={512.18103,5.0014391,284.77197};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -10001,7 +10114,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item2
@@ -10009,12 +10135,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.08191,5.0014391,286.88123};
+						position[]={516.08197,5.0014391,286.88098};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -10050,7 +10177,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -10107,12 +10247,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.7399,5.0014391,288.98419};
+						position[]={510.73999,5.0014391,288.98398};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -10148,7 +10289,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5
@@ -10237,12 +10391,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={514.45264,5.0014391,258.78809};
+						position[]={514.453,5.0014391,258.78799};
 					};
 					side="East";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@TANGO-2";
 						isPlayable=1;
@@ -10278,7 +10433,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -10286,12 +10454,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={511.88062,5.0014391,251.85912};
+						position[]={511.88101,5.0014391,251.85901};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -10327,7 +10496,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item2
@@ -10335,12 +10517,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={515.78162,5.0014391,253.96811};
+						position[]={515.78198,5.0014391,253.968};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -10376,7 +10559,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -10433,12 +10629,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.43964,5.0014391,256.07111};
+						position[]={510.44,5.0014391,256.07098};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -10474,7 +10671,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5
@@ -10563,12 +10773,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={515.11865,5.0014391,227.93512};
+						position[]={515.11902,5.0014391,227.935};
 					};
 					side="East";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@TANGO-3";
 						isPlayable=1;
@@ -10604,7 +10815,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -10612,12 +10836,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={512.54645,5.0014391,221.00676};
+						position[]={512.54602,5.0014391,221.007};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -10653,7 +10878,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item2
@@ -10661,12 +10899,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.44745,5.0014391,223.11575};
+						position[]={516.44702,5.0014391,223.116};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -10702,7 +10941,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -10759,12 +11011,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={511.10547,5.0014391,225.21873};
+						position[]={511.10501,5.0014391,225.21901};
 					};
 					side="East";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -10800,7 +11053,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5
@@ -10889,12 +11155,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={449.83701,5.0014391,259.00403};
+						position[]={449.83701,5.0014391,259.004};
 					};
 					side="Independent";
 					flags=3;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""co"", this] call f_fnc_assignGear;" \n "this setVariable [""f_leaderGroup"", true]";
 						description="Commander@INDIA";
 						isPlayable=1;
@@ -10930,7 +11197,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -10938,12 +11218,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={451.59326,5.0014391,254.35474};
+						position[]={451.59299,5.0014391,254.355};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""co"", this] call f_fnc_assignGear;";
 						description="Executive Officer";
 						isPlayable=1;
@@ -10979,7 +11260,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item2
@@ -10987,12 +11281,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={455.47424,5.0014391,252.93974};
+						position[]={455.474,5.0014391,252.94};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""fac"", this] call f_fnc_assignGear;";
 						description="Forward Air Controller";
 						isPlayable=1;
@@ -11028,7 +11323,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -11036,12 +11344,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={446.32324,5.0014391,255.59471};
+						position[]={446.323,5.0014391,255.595};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="LIEUTENANT";
 						init="[""med"", this] call f_fnc_assignGear;";
 						description="Medic";
 						isPlayable=1;
@@ -11090,7 +11399,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item4
@@ -11098,12 +11420,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={442.17725,5.0014391,256.89075};
+						position[]={442.177,5.0014391,256.89099};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -11152,7 +11475,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item5
@@ -11160,12 +11496,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={448.09424,5.0014391,251.41273};
+						position[]={448.09399,5.0014391,251.41301};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""eng"", this] call f_fnc_assignGear;";
 						description="Logistics";
 						isPlayable=1;
@@ -11214,7 +11551,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item6
@@ -11222,12 +11572,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={447.35223,5.0014391,247.96674};
+						position[]={447.35199,5.0014391,247.96701};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""eng"", this] call f_fnc_assignGear;";
 						description="Logistics";
 						isPlayable=1;
@@ -11276,7 +11627,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 			};
@@ -11316,12 +11680,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={419.09262,5.0014391,290.9281};
+						position[]={419.09299,5.0014391,290.92798};
 					};
 					side="Independent";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@INDIA-1";
 						isPlayable=1;
@@ -11357,7 +11722,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -11365,12 +11743,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={416.69684,5.0014391,284.05151};
+						position[]={416.69699,5.0014391,284.052};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -11419,7 +11798,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item2
@@ -11427,12 +11819,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={420.49084,5.0014391,285.87054};
+						position[]={420.491,5.0014391,285.871};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -11468,7 +11861,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -11525,12 +11931,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={414.64383,5.0014391,288.27454};
+						position[]={414.64401,5.0014391,288.27499};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -11566,7 +11973,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5
@@ -11655,12 +12075,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={419.11563,5.0014391,258.69312};
+						position[]={419.116,5.0014391,258.69299};
 					};
 					side="Independent";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@INDIA-2";
 						isPlayable=1;
@@ -11696,7 +12117,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -11704,12 +12138,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={416.71979,5.0014391,251.81598};
+						position[]={416.72,5.0014391,251.81601};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -11758,7 +12193,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item2
@@ -11766,12 +12214,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={420.51379,5.0014391,253.63498};
+						position[]={420.51401,5.0014391,253.63501};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -11807,7 +12256,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -11815,7 +12277,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={422.61679,5.0014391,248.642};
+						position[]={422.617,5.0014391,248.642};
 					};
 					side="Independent";
 					flags=1;
@@ -11856,7 +12318,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item4
@@ -11864,12 +12339,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={414.66678,5.0014391,256.039};
+						position[]={414.66699,5.0014391,256.039};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -11905,7 +12381,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5
@@ -11994,12 +12483,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={418.54962,5.0014391,227.20111};
+						position[]={418.54999,5.0014391,227.201};
 					};
 					side="Independent";
 					flags=3;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""ftl"", this] call f_fnc_assignGear;";
 						description="Fireteam Leader@INDIA-3";
 						isPlayable=1;
@@ -12035,7 +12525,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item1
@@ -12043,12 +12546,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={416.15366,5.0014391,220.32391};
+						position[]={416.15399,5.0014391,220.32401};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="SERGEANT";
 						init="[""cls"", this] call f_fnc_assignGear;";
 						description="Combat Lifesaver";
 						isPlayable=1;
@@ -12097,7 +12601,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=3;
+						class Attribute3
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=4;
 					};
 				};
 				class Item2
@@ -12105,12 +12622,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={419.94766,5.0014391,222.14291};
+						position[]={419.948,5.0014391,222.14301};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""ar"", this] call f_fnc_assignGear;";
 						description="Autorifleman";
 						isPlayable=1;
@@ -12146,7 +12664,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item3
@@ -12203,12 +12734,13 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={414.10065,5.0014391,224.54692};
+						position[]={414.10101,5.0014391,224.547};
 					};
 					side="Independent";
 					flags=1;
 					class Attributes
 					{
+						rank="CORPORAL";
 						init="[""lat"", this] call f_fnc_assignGear;";
 						description="Anti-tank";
 						isPlayable=1;
@@ -12244,7 +12776,20 @@ class Mission
 								};
 							};
 						};
-						nAttributes=2;
+						class Attribute2
+						{
+							property="acre_sys_radio_edenSetup";
+							expression="_this setVariable [""acre_sys_radio_setup"", _value, true]";
+							class Value
+							{
+								class data
+								{
+									singleType="STRING";
+									value="[[""ACRE_PRC343"",[1,1]],[""ACRE_PRC152"",1],[""ACRE_PRC117F"",1]]";
+								};
+							};
+						};
+						nAttributes=3;
 					};
 				};
 				class Item5


### PR DESCRIPTION
### Pull Request Description
**When merged this pull request will:**
- Add ranks to the OPFOR and INDFOR player groups in the default mission, closing #311 
- Overwrite the radios set in EDEN attributes, closing #321 

### Release Notes
_The default OPFOR and INDFOR player groups now have ranks, and that pesky radio misalignment at mission start bug has been patched._

## IMPORTANT

- [x] Testing has been completed as neccessary, depending on the nature & impact of the changes.
- [x] The Release Notes section below must be filled out appropriately to explain the changes made in this PR. This section will be used in Framework Changelogs.
- [x] If the contribution affects [the wiki](https://github.com/CombinedArmsGaming/CAFE3/wiki), please include your changes in this pull request so the wiki is consistently updated.
- [x] [Contribution Guidelines](https://github.com/CombinedArmsGaming/CAFE3/blob/release/contributing.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `[Descriptor] - Add|Fix|Improve|Change|Make|Remove {changes}`.

